### PR TITLE
Optimized the use of java.lang.Class#getInterfaces() in OgnlCompiler

### DIFF
--- a/src/java/ognl/enhance/ExpressionCompiler.java
+++ b/src/java/ognl/enhance/ExpressionCompiler.java
@@ -202,8 +202,11 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
         if (Modifier.isPublic(clazz.getModifiers()) && clazz.isInterface())
             return clazz.getName();
 
-        Class[] intf = clazz.getInterfaces();
+        return _getClassName(clazz, clazz.getInterfaces());
+    }
 
+    private String _getClassName(Class clazz, Class[] intf)
+    {
         for (int i = 0; i < intf.length; i++)
         {
             if (intf[i].getName().indexOf("util.List") > 0)
@@ -212,17 +215,22 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
                 return intf[i].getName();
         }
 
-        if (clazz.getSuperclass() != null && clazz.getSuperclass().getInterfaces().length > 0)
-            return getClassName(clazz.getSuperclass());
+        final Class superclazz = clazz.getSuperclass();
+        if (superclazz != null)
+        {
+            final Class[] superclazzIntf = superclazz.getInterfaces();
+            if (superclazzIntf.length > 0)
+                return _getClassName(superclazz, superclazzIntf);
+        }
 
         return clazz.getName();
     }
 
     public Class getSuperOrInterfaceClass(Method m, Class clazz)
     {
-        if (clazz.getInterfaces() != null && clazz.getInterfaces().length > 0)
+        Class[] intfs = clazz.getInterfaces();
+        if (intfs != null && intfs.length > 0)
         {
-            Class[] intfs = clazz.getInterfaces();
             Class intClass;
 
             for (int i = 0; i < intfs.length; i++)
@@ -331,8 +339,11 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
             && clazz.isInterface() || clazz.isPrimitive())
             return clazz;
 
-        Class[] intf = clazz.getInterfaces();
+        return _getInterfaceClass(clazz, clazz.getInterfaces());
+    }
 
+    private Class _getInterfaceClass(Class clazz, Class[] intf)
+    {
         for (int i = 0; i < intf.length; i++)
         {
             if (List.class.isAssignableFrom(intf[i]))
@@ -347,8 +358,13 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
                 return Collection.class;
         }
 
-        if (clazz.getSuperclass() != null && clazz.getSuperclass().getInterfaces().length > 0)
-            return getInterfaceClass(clazz.getSuperclass());
+        final Class superclazz = clazz.getSuperclass();
+        if (superclazz != null)
+        {
+            final Class[] superclazzIntf = superclazz.getInterfaces();
+            if (superclazzIntf.length > 0)
+                return _getInterfaceClass(superclazz, superclazzIntf);
+        }
 
         return clazz;
     }


### PR DESCRIPTION
Most of my profiling sessions show `java.lang.Class#getInterfaces()` as one of the *hot spots* under heavy OGNL load, because of being used at several methods in `ognl.enhance.ExpressionCompiler`, especially `ognl.enhance.ExpressionCompiler#getInterfaceClass(java.lang.Class)`

Indeed it seems this `java.lang.Class#getInterfaces()` method, even if being native, is quite slow for some strange reason. I've read a couple of complaints about it also related with Hibernate (see [1] and [2]).

Fortunately, I was able to importantly reduce the amount of times this method has to be called in `ExpressionCompiler` without losing any functionality, just re-structuring a bit the code. This should save a noticeable amount of execution time.

[1] https://forum.hibernate.org/viewtopic.php?p=2404651
[2] https://jira.atlassian.com/browse/CRUC-4518