### PR TITLE
Optimization: avoid using java.lang.String#replaceAll() in most cases

### DIFF
--- a/src/java/ognl/ASTAdd.java
+++ b/src/java/ognl/ASTAdd.java
@@ -223,7 +223,8 @@ class ASTAdd extends NumericExpression
                     if (context.getCurrentType() != null && context.getCurrentType() == Character.class
                         && ASTConst.class.isInstance(_children[i]))
                     {
-                        expr = expr.replaceAll("'", "\"");
+                        if (expr.indexOf('\'') >= 0)
+                            expr = expr.replaceAll("'", "\"");
                         context.setCurrentType(String.class);
                     } else {
 
@@ -240,8 +241,10 @@ class ASTAdd extends NumericExpression
                             if (lastType != null && String.class.isAssignableFrom(lastType.getGetterClass()))
                             {
                                 //System.out.println("Input expr >>" + expr + "<<");
-                                expr = expr.replaceAll("&quot;", "\"");
-                                expr = expr.replaceAll("\"", "'");
+                                if (expr.indexOf("&quot;") >= 0)
+                                    expr = expr.replaceAll("&quot;", "\"");
+                                if (expr.indexOf('"') >= 0)
+                                    expr = expr.replaceAll("\"", "'");
                                 expr = "\"" + expr + "\"";
                                 //System.out.println("Expr now >>" + expr + "<<");
                             }

--- a/src/java/ognl/ListPropertyAccessor.java
+++ b/src/java/ognl/ListPropertyAccessor.java
@@ -131,7 +131,8 @@ public class ListPropertyAccessor extends ObjectPropertyAccessor implements Prop
     public Class getPropertyClass(OgnlContext context, Object target, Object index)
     {
         if (index instanceof String) {
-            String key = ((String)index).replaceAll("\"", "");
+            String indexStr = (String)index;
+            String key = (indexStr.indexOf('"') >= 0? indexStr.replaceAll("\"", "") : indexStr);
             if (key.equals("size")) {
                 return int.class;
             } else {
@@ -155,7 +156,9 @@ public class ListPropertyAccessor extends ObjectPropertyAccessor implements Prop
 
     public String getSourceAccessor(OgnlContext context, Object target, Object index)
     {
-        String indexStr = index.toString().replaceAll("\"", "");
+        String indexStr = index.toString();
+        if (indexStr.indexOf('"') >= 0)
+            indexStr = indexStr.replaceAll("\"", "");
 
         if (String.class.isInstance(index)) 
         {
@@ -225,7 +228,9 @@ public class ListPropertyAccessor extends ObjectPropertyAccessor implements Prop
 
     public String getSourceSetter(OgnlContext context, Object target, Object index)
     {
-        String indexStr = index.toString().replaceAll("\"", "");
+        String indexStr = index.toString();
+        if (indexStr.indexOf('"') >= 0)
+            indexStr = indexStr.replaceAll("\"", "");
 
         // TODO: This feels really inefficient, must be some better way
         // check if the index string represents a method on a custom class implementing java.util.List instead..

--- a/src/java/ognl/MapPropertyAccessor.java
+++ b/src/java/ognl/MapPropertyAccessor.java
@@ -113,7 +113,7 @@ public class MapPropertyAccessor implements PropertyAccessor
         
         if (String.class.isInstance(index) && !indexedAccess)
         {
-            String key = indexStr.replaceAll("\"", "");
+            String key = (indexStr.indexOf('"') >= 0? indexStr.replaceAll("\"", "") : indexStr);
 
             if (key.equals("size")) {
                 context.setCurrentType(int.class);
@@ -142,7 +142,7 @@ public class MapPropertyAccessor implements PropertyAccessor
 
         if (String.class.isInstance(index))
         {
-            String key = indexStr.replaceAll("\"", "");
+            String key = (indexStr.indexOf('"') >= 0? indexStr.replaceAll("\"", "") : indexStr);
             
             if (key.equals("size"))
                 return "";

--- a/src/java/ognl/ObjectPropertyAccessor.java
+++ b/src/java/ognl/ObjectPropertyAccessor.java
@@ -175,7 +175,8 @@ public class ObjectPropertyAccessor implements PropertyAccessor {
             if (m == null) {
 
                 if (String.class.isAssignableFrom(index.getClass()) && !target.getClass().isArray()) {
-                    String key = ((String) index).replaceAll("\"", "");
+                    String indexStr = (String)index;
+                    String key = (indexStr.indexOf('"') >= 0)? indexStr.replaceAll("\"", "") : indexStr;
                     try {
                         Field f = target.getClass().getField(key);
                         if (f != null) {
@@ -202,13 +203,17 @@ public class ObjectPropertyAccessor implements PropertyAccessor {
     {
         try {
 
-            String methodName = index.toString().replaceAll("\"", "");
+            String indexStr = index.toString();
+            String methodName = (indexStr.indexOf('"') >= 0? indexStr.replaceAll("\"", "") : indexStr);
             Method m = OgnlRuntime.getReadMethod(target.getClass(), methodName);
 
             // try last ditch effort of checking if they were trying to do reflection via a return method value
 
             if (m == null && context.getCurrentObject() != null)
-                m = OgnlRuntime.getReadMethod(target.getClass(), context.getCurrentObject().toString().replaceAll("\"", ""));
+            {
+                String currentObjectStr = context.getCurrentObject().toString();
+                m = OgnlRuntime.getReadMethod(target.getClass(), (currentObjectStr.indexOf('"') >= 0? currentObjectStr.replaceAll("\"", "") : currentObjectStr));
+            }
 
             //System.out.println("tried to get read method from target: " + target.getClass() + " with methodName:" + methodName + " result: " + m);
             // try to get field if no method could be found
@@ -252,13 +257,15 @@ public class ObjectPropertyAccessor implements PropertyAccessor {
     {
         try {
 
-            String methodName = index.toString().replaceAll("\"", "");
+            String indexStr = index.toString();
+            String methodName = (indexStr.indexOf('"') >= 0? indexStr.replaceAll("\"", "") : indexStr);
             Method m = OgnlRuntime.getWriteMethod(target.getClass(), methodName);
 
             if (m == null && context.getCurrentObject() != null
                 && context.getCurrentObject().toString() != null)
             {
-                m = OgnlRuntime.getWriteMethod(target.getClass(), context.getCurrentObject().toString().replaceAll("\"", ""));
+                String currentObjectStr = context.getCurrentObject().toString();
+                m = OgnlRuntime.getWriteMethod(target.getClass(), (currentObjectStr.indexOf('"') >= 0? currentObjectStr.replaceAll("\"", "") : currentObjectStr));
             }
 
             if (m == null || m.getParameterTypes() == null || m.getParameterTypes().length <= 0)

--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -2675,7 +2675,10 @@ public class OgnlRuntime {
     public static Method getReadMethod(Class target, String name, int numParms)
     {
         try {
-            name = name.replaceAll("\"", "").toLowerCase();
+            if (name.indexOf('"') >= 0)
+                name = name.replaceAll("\"", "");
+
+            name = name.toLowerCase();
 
             BeanInfo info = Introspector.getBeanInfo(target);
             MethodDescriptor[] methods = info.getMethodDescriptors();
@@ -2763,7 +2766,8 @@ public class OgnlRuntime {
     public static Method getWriteMethod(Class target, String name, int numParms)
     {
         try {
-            name = name.replaceAll("\"", "");
+            if (name.indexOf('"') >= 0)
+                name = name.replaceAll("\"", "");
 
             BeanInfo info = Introspector.getBeanInfo(target);
             MethodDescriptor[] methods = info.getMethodDescriptors();

--- a/src/java/ognl/enhance/ExpressionCompiler.java
+++ b/src/java/ognl/enhance/ExpressionCompiler.java
@@ -530,7 +530,8 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
                    + ";}";
         }
 
-        body = body.replaceAll("\\.\\.", ".");
+        if (body.indexOf("..") >= 0)
+            body = body.replaceAll("\\.\\.", ".");
 
 //        System.out.println("Getter Body: ===================================\n" + body);
         valueGetter.setBody(body);
@@ -570,7 +571,8 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
             body += " return  " + widener + ref.getExpression() + ";";
             body += "}";
 
-            body = body.replaceAll("\\.\\.", ".");
+            if (body.indexOf("..") >= 0)
+                body = body.replaceAll("\\.\\.", ".");
 
 //            System.out.println("adding method " + ref.getName() + " with body:\n" + body + " and return type: " + ref.getType());
 
@@ -618,7 +620,8 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
                + pre
                + setterCode + ";}";
 
-        body = body.replaceAll("\\.\\.", ".");
+        if (body.indexOf("..") >= 0)
+            body = body.replaceAll("\\.\\.", ".");
 
 //        System.out.println("Setter Body: ===================================\n" + body);
 


### PR DESCRIPTION
Several parts of OGNL call the `java.lang.String#replaceAll(...)` method, which is extremely inefficient because it first compiles a `java.util.regex.Pattern`, then a `Matcher`, and finally asks this `Matcher` to perform the replace operation.

In order to avoid most of the calls to this method without disrupting the code base too much, I've added before each call a condition based on a call to `java.lang.String#indexOf(...)`, which is hugely more efficient because it acts directly on the `String`'s inner `char[]`. And only if this `indexOf(...)` determines there is a possibility that the `replaceAll(...)` operation would actually *do something*, `replaceAll(...)` will be called.