### PR TITLE
OGNL-158 Statics within Enums causing IllegalArgumentExceptions

### DIFF
--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -1804,15 +1804,18 @@ public class OgnlRuntime {
                 return c;
             } else if (OgnlRuntime.isJdk15() && c.isEnum())
             {
-                return Enum.valueOf(c, fieldName);
-            } else
-            {
-                Field f = c.getField(fieldName);
-                if (!Modifier.isStatic(f.getModifiers()))
-                    throw new OgnlException("Field " + fieldName + " of class " + className + " is not static");
-
-                return f.get(null);
+                try {
+                    return Enum.valueOf(c, fieldName);
+                } catch (IllegalArgumentException e) {
+                    // ignore it, try static field
+                }
             }
+
+            Field f = c.getField(fieldName);
+            if (!Modifier.isStatic(f.getModifiers()))
+                throw new OgnlException("Field " + fieldName + " of class " + className + " is not static");
+
+            return f.get(null);
         } catch (ClassNotFoundException e) {
             reason = e;
         } catch (NoSuchFieldException e) {

--- a/src/test/java/ognl/TestOgnlRuntime.java
+++ b/src/test/java/ognl/TestOgnlRuntime.java
@@ -308,4 +308,22 @@ public class TestOgnlRuntime extends TestCase {
         Object value = Ognl.getValue("!'false'", new Object());
         assertEquals(Boolean.TRUE, value);
     }
+
+    public void testGetStaticField() throws Exception {
+        OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null);
+        Object obj = OgnlRuntime.getStaticField(context, "org.ognl.test.objects.Root", "SIZE_STRING");
+        assertEquals(Root.SIZE_STRING, obj);
+    }
+
+    public void testGetStaticFieldEnum() throws Exception {
+        OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null);
+        Object obj = OgnlRuntime.getStaticField(context, "org.ognl.test.objects.OtherEnum", "ONE");
+        assertEquals(OtherEnum.ONE, obj);
+    }
+
+    public void testGetStaticFieldEnumStatic() throws Exception {
+        OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null);
+        Object obj = OgnlRuntime.getStaticField(context, "org.ognl.test.objects.OtherEnum", "STATIC_STRING");
+        assertEquals(OtherEnum.STATIC_STRING, obj);
+    }
 }

--- a/src/test/java/org/ognl/test/objects/OtherEnum.java
+++ b/src/test/java/org/ognl/test/objects/OtherEnum.java
@@ -1,0 +1,23 @@
+package org.ognl.test.objects;
+
+/**
+ *
+ */
+public enum OtherEnum {
+
+    ONE (1);
+
+    public static final String STATIC_STRING = "string";
+
+    private int _value;
+
+    private OtherEnum(int value)
+    {
+        _value = value;
+    }
+
+    public int getValue()
+    {
+        return _value;
+    }
+}


### PR DESCRIPTION
OGNL-158 Statics within Enums causing IllegalArgumentExceptions (WW-4479 Ognl can't access static field on enum)