### PR TITLE
Update OgnlRuntime.java

### DIFF
--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -1661,7 +1661,6 @@ public class OgnlRuntime {
                 if (o == null) {
                     _superclasses.clear();
                     for (Class sc = inClass; (sc != null); sc = sc.getSuperclass()) {
-                        if ((o = getFields(sc).get(name)) == NotFound)
                             break;
 
                         _superclasses.add(sc);
@@ -1849,15 +1848,15 @@ public class OgnlRuntime {
                 return propertyName;
             }
         }
-        char first = propertyName.charAt(0);
-        char second = propertyName.charAt(1);
-        if (Character.isLowerCase(first) && Character.isUpperCase(second)) {
-            return propertyName;
-        } else {
+        //char first = propertyName.charAt(0);
+        //char second = propertyName.charAt(1);
+        //if (Character.isLowerCase(first) && Character.isUpperCase(second)) {
+        //    return propertyName;
+        //} else {
             char[] chars = propertyName.toCharArray();
             chars[0] = Character.toUpperCase(chars[0]);
             return new String(chars);
-        }
+        //}
     }
 
     public static List getDeclaredMethods(Class targetClass, String propertyName, boolean findSets)


### PR DESCRIPTION
this position is not comfortable with version 3.0.6, for example, javabean field name is sL, set method should be setSL(), if use version 3.0.13,  set method return setsL(), it's wrong,  then sL cann't be set value