### PR TITLE
Update OgnlRuntime.java

### DIFF
--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -1849,15 +1849,11 @@ public class OgnlRuntime {
                 return propertyName;
             }
         }
-        char first = propertyName.charAt(0);
-        char second = propertyName.charAt(1);
-        if (Character.isLowerCase(first) && Character.isUpperCase(second)) {
-            return propertyName;
-        } else {
-            char[] chars = propertyName.toCharArray();
-            chars[0] = Character.toUpperCase(chars[0]);
-            return new String(chars);
-        }
+
+        char[] chars = propertyName.toCharArray();
+        chars[0] = Character.toUpperCase(chars[0]);
+        return new String(chars);
+        
     }
 
     public static List getDeclaredMethods(Class targetClass, String propertyName, boolean findSets)


### PR DESCRIPTION
this position is not comfortable with version 3.0.6, for example, javabean field name is sL, set method should be setSL(), if use version 3.0.13,  set method return setsL(), it's wrong,  then sL cann't be set value