### PR TITLE
Issue 23

### DIFF
--- a/src/test/java/org/ognl/test/MethodTest.java
+++ b/src/test/java/org/ognl/test/MethodTest.java
@@ -31,6 +31,10 @@
 package org.ognl.test;
 
 import junit.framework.TestSuite;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.ognl.test.objects.*;
 
 public class MethodTest extends OgnlTestCase
@@ -71,6 +75,8 @@ public class MethodTest extends OgnlTestCase
             //   Java 'ROOT.getTestMethods().argsTest1(Arrays.asList( ROOT.getOne() )' doesn't compile:
             //		--> The method argsTest(Object[]) in the type MethodTestMethods is not applicable for the arguments (List<Integer>)
             { "testMethods.argsTest3({one})", "List: [1]" },
+            //	https://github.com/jkuhnert/ognl/issues/23 - Exception selecting overloaded method in 3.1.4
+            { "testMethods.avg({ 5, 5 })", ROOT.getTestMethods().avg((List)Arrays.asList(5, 5)) },
     };
 
     public static class A

--- a/src/test/java/org/ognl/test/objects/MethodTestMethods.java
+++ b/src/test/java/org/ognl/test/objects/MethodTestMethods.java
@@ -56,4 +56,73 @@ public class MethodTestMethods {
         return "List: "+data;
     }
 
+    //---------------------------------------------------------------------
+    // https://github.com/jkuhnert/ognl/issues/23
+    // 'avg' tests
+    //---------------------------------------------------------------------
+    public double avg(final Iterable<? extends Number> target) {
+        double total = 0;
+        int size = 0;
+        for (final Number element : target) {
+            total += element.doubleValue();
+            size++;
+        }
+        return total/size;
+    }
+
+    public double avg(final Number[] target) {
+        double total = 0;
+        for (final Number element : target) {
+            total += element.doubleValue();
+        }
+        return total/target.length;
+    }
+
+    public double avg(final byte[] target) {
+        double total = 0;
+        for (final Number element : target) {
+            total += element.doubleValue();
+        }
+        return total/target.length;
+    }
+
+    public double avg(final short[] target) {
+        double total = 0;
+        for (final Number element : target) {
+            total += element.doubleValue();
+        }
+        return total/target.length;
+    }
+
+    public double avg(final int[] target) {
+        double total = 0;
+        for (final Number element : target) {
+            total += element.doubleValue();
+        }
+        return total/target.length;
+    }
+
+    public double avg(final long[] target) {
+        double total = 0;
+        for (final Number element : target) {
+            total += element.doubleValue();
+        }
+        return total/target.length;
+    }
+
+    public double avg(final float[] target) {
+        double total = 0;
+        for (final Number element : target) {
+            total += element.doubleValue();
+        }
+        return total/target.length;
+    }
+
+    public double avg(final double[] target) {
+        double total = 0;
+        for (final Number element : target) {
+            total += element.doubleValue();
+        }
+        return total/target.length;
+    }
 }


### PR DESCRIPTION
Bugfix for https://github.com/jkuhnert/ognl/issues/23 - Exception selecting overloaded method in 3.1.4

- Improved method matching: Lists default to List<Object> because of "Java Generics Type Erasure"
- Don't bail out (with exception) immedeately if we get two methods with same score - a method with a  better score might follow. Just remember the Exception and if we really don't get an better option throw the exception