### PR TITLE
Backporting #40 to ognl-3-1-x branch.

### DIFF
--- a/src/test/java/ognl/Java8Test.java
+++ b/src/test/java/ognl/Java8Test.java
@@ -22,9 +22,11 @@ public class Java8Test extends TestCase {
 
 class SubClassWithDefaults extends ClassWithDefaults {
 
+	public String getName() { return "name"; }
+
 }
 
-class ClassWithDefaults /* implements InterfaceWithDefaults */ {
+class ClassWithDefaults /* implements SubInterfaceWithDefaults */ {
 
 }
 
@@ -33,5 +35,8 @@ class ClassWithDefaults /* implements InterfaceWithDefaults */ {
  *
 interface InterfaceWithDefaults {
     default public void defaultMethod() { }
+    default public String getName() { return "name"; }
+}
+interface SubInterfaceWithDefaults extends InterfaceWithDefaults {
 }
  */


### PR DESCRIPTION
When scanning super interfaces in `OgnlRuntime#getMethods(Class, boolean)`, only default methods should be collected instead of all declared methods.
Also, super interfaces should be searched recursively so that it can handle deeper interface hierarchy.