### PR TITLE
Allow override a strategy for loading Class on DefaultClassResolver

### DIFF
--- a/src/main/java/ognl/DefaultClassResolver.java
+++ b/src/main/java/ognl/DefaultClassResolver.java
@@ -55,8 +55,13 @@ public class DefaultClassResolver extends Object implements ClassResolver
         if (result != null) {
             return result;
         }
-        result = (className.indexOf('.') == -1) ? Class.forName("java.lang." + className) : Class.forName(className);
+        result = (className.indexOf('.') == -1) ? toClassForName("java.lang." + className) : toClassForName(className);
         classes.put(className, result);
         return result;
     }
+
+    protected Class toClassForName(String className) throws ClassNotFoundException {
+        return Class.forName(className);
+    }
+
 }


### PR DESCRIPTION
I will propose to allow override a strategy for loading Class. Actually, the MyBatis core module want to override strategy using this extending point. Currently, we copy the `DefaultClassResolver` and modify a class loading logic.

WDYT? 