### PR TITLE
getReadMethod() should check default methods as well.

### DIFF
--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -1795,7 +1795,7 @@ public class OgnlRuntime {
             }
         }
         return result;
-                    }
+    }
 
     private static void collectMethods(Class c, Map result, boolean staticMethods) {
         Method[] ma = c.getDeclaredMethods();
@@ -2931,15 +2931,14 @@ public class OgnlRuntime {
 
             name = name.toLowerCase();
 
-            BeanInfo info = Introspector.getBeanInfo(target);
-            MethodDescriptor[] methods = info.getMethodDescriptors();
+            Method[] methods = target.getMethods();
 
             // exact matches first
             ArrayList<Method> candidates = new ArrayList<Method>();
 
             for (int i = 0; i < methods.length; i++)
             {
-                if (!isMethodCallable(methods[i].getMethod()))
+                if (!isMethodCallable(methods[i]))
                     continue;
 
                 if ((methods[i].getName().equalsIgnoreCase(name)
@@ -2948,7 +2947,7 @@ public class OgnlRuntime {
                      || methods[i].getName().toLowerCase().equals("is" + name))
                     && !methods[i].getName().startsWith("set"))
                 {
-                    candidates.add(methods[i].getMethod());
+                    candidates.add(methods[i]);
                 }
             }
             if (!candidates.isEmpty()) {
@@ -2959,7 +2958,7 @@ public class OgnlRuntime {
 
             for (int i = 0; i < methods.length; i++)
             {
-                if (!isMethodCallable(methods[i].getMethod()))
+                if (!isMethodCallable(methods[i]))
                     continue;
 
                 if (methods[i].getName().equalsIgnoreCase(name)
@@ -2967,9 +2966,9 @@ public class OgnlRuntime {
                     && !methods[i].getName().startsWith("get")
                     && !methods[i].getName().startsWith("is")
                     && !methods[i].getName().startsWith("has")
-                    && methods[i].getMethod().getReturnType() != Void.TYPE) {
+                    && methods[i].getReturnType() != Void.TYPE) {
 
-                    Method m = methods[i].getMethod();
+                    Method m = methods[i];
                     if (!candidates.contains(m))
                         candidates.add(m);
                 }

--- a/src/test/java/ognl/Java8Test.java
+++ b/src/test/java/ognl/Java8Test.java
@@ -1,5 +1,6 @@
 package ognl;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 import junit.framework.TestCase;
@@ -10,20 +11,21 @@ public class Java8Test extends TestCase {
         /* defaultMethod(); */
         List defaultMethod = OgnlRuntime.getMethods(ClassWithDefaults.class, "defaultMethod", false);
         assertNotNull(defaultMethod);
+        Method method = OgnlRuntime.getReadMethod(ClassWithDefaults.class, "defaultMethod");
+        assertNotNull(method);
     }
 
     public void testDefaultMethodOnSubClass() {
         /* defaultMethod(); */
         List defaultMethod = OgnlRuntime.getMethods(SubClassWithDefaults.class, "defaultMethod", false);
         assertNotNull(defaultMethod);
+        Method method = OgnlRuntime.getReadMethod(SubClassWithDefaults.class, "defaultMethod");
+        assertNotNull(method);
     }
 
 }
 
 class SubClassWithDefaults extends ClassWithDefaults {
-
-	public String getName() { return "name"; }
-
 }
 
 class ClassWithDefaults /* implements SubInterfaceWithDefaults */ {


### PR DESCRIPTION
This was fixed in master via #33, but was not backported to 3.1.x branch.