### PR TITLE
Update OGNL 3.1.x build configuration, enhance unit test and cleanup restore method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.9</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>2.3</version>
+            <version>2.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -101,7 +101,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.3</version>
+                <version>2.22.1</version>  <!-- Most recent 2.x available -->
                 <configuration>
                     <excludes>
                         <exclude>**/OgnlTestCase.java</exclude>
@@ -161,9 +161,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>2.6.1</version>  <!-- Most recent 2.x available -->
             </plugin>
         </plugins>
+
+        <defaultGoal>install</defaultGoal>
+
     </build>
 
 </project>

--- a/src/java/ognl/DefaultMemberAccess.java
+++ b/src/java/ognl/DefaultMemberAccess.java
@@ -108,7 +108,7 @@ public class DefaultMemberAccess implements MemberAccess
         Object      result = null;
 
         if (isAccessible(context, target, member, propertyName)) {
-            AccessibleObject    accessible = (AccessibleObject)member;
+            AccessibleObject    accessible = (AccessibleObject) member;
 
             if (!accessible.isAccessible()) {
                 result = Boolean.FALSE;
@@ -121,7 +121,14 @@ public class DefaultMemberAccess implements MemberAccess
     public void restore(Map context, Object target, Member member, String propertyName, Object state)
     {
         if (state != null) {
-            ((AccessibleObject)member).setAccessible(((Boolean)state).booleanValue());
+            final AccessibleObject  accessible = (AccessibleObject) member;
+            final boolean           stateboolean = ((Boolean) state).booleanValue();  // Using twice (avoid unboxing)
+            if (!stateboolean) {
+                accessible.setAccessible(stateboolean);
+            } else {
+                throw new IllegalArgumentException("Improper restore state [" + stateboolean + "] for target [" + target +
+                                                   "], member [" + member + "], propertyName [" + propertyName + "]");
+            }
         }
     }
 

--- a/src/test/java/org/ognl/test/PrivateMemberTest.java
+++ b/src/test/java/org/ognl/test/PrivateMemberTest.java
@@ -36,13 +36,15 @@ import ognl.DefaultMemberAccess;
 import ognl.Ognl;
 import ognl.OgnlContext;
 import ognl.OgnlException;
+import ognl.OgnlRuntime;
 
 /**
  * This is a test program for private access in OGNL.
- * shows the failures and a summary.
+ * Shows the failures and a summary.
  */
 public class PrivateMemberTest extends TestCase
 {
+    private static String           _privateStaticProperty = "private static value";
     private String                  _privateProperty = "private value";
     protected OgnlContext           context;
 
@@ -64,13 +66,20 @@ public class PrivateMemberTest extends TestCase
 	}
 
 	/*===================================================================
-		Public methods
+		Private methods
 	  ===================================================================*/
     private String getPrivateProperty()
     {
         return _privateProperty;
     }
 
+    private static String getPrivateStaticProperty() {
+        return _privateStaticProperty;
+    }
+
+  /*===================================================================
+    Public methods
+    ===================================================================*/
     public void testPrivateAccessor() throws OgnlException
     {
         assertEquals(Ognl.getValue("privateProperty", context, this), getPrivateProperty());
@@ -79,6 +88,89 @@ public class PrivateMemberTest extends TestCase
     public void testPrivateField() throws OgnlException
     {
         assertEquals(Ognl.getValue("_privateProperty", context, this), _privateProperty);
+    }
+
+    public void testPrivateStaticAccessor() throws OgnlException
+    {
+        // Test following PR#59/PR#60 (MemberAccess support private static field).
+        assertEquals(Ognl.getValue("privateStaticProperty", context, this), getPrivateStaticProperty());
+        // Succeeds due to calling the static getter to retrieve it.
+    }
+
+    public void testPrivateStaticFieldNormalAccess() throws OgnlException
+    {
+        // Test following PR#59/PR#60 (MemberAccess support private static field).
+        try {
+            assertEquals(Ognl.getValue("_privateStaticProperty", context, this), _privateStaticProperty);
+            fail("Should not be able to access private static _privateStaticProperty through getValue()");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a static field using non-static getValue
+        }
+    }
+
+    public void testPrivateStaticFieldStaticAccess() throws OgnlException
+    {
+        // Test following PR#59/PR#60 (MemberAccess support private static field).
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_privateStaticProperty"), _privateStaticProperty);
+        // Only succeeds due to directly using the runtime to access the field as a static field.
+    }
+
+    public void testPrivateAccessorFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, true, true));  // Prevent private access
+        try {
+          assertEquals(Ognl.getValue("privateProperty", context, this), getPrivateProperty());
+          fail("Should not be able to access private property with private access turned off");
+        } catch (OgnlException oex) {
+          // Fails as test attempts to access a private accessor with private access turned off
+        }
+    }
+
+    public void testPrivateFieldFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, true, true));  // Prevent private access
+        try {
+          assertEquals(Ognl.getValue("_privateProperty", context, this), _privateProperty);
+          fail("Should not be able to access private property with private access turned off");
+        } catch (OgnlException oex) {
+          // Fails as test attempts to access a private accessor with private access turned off
+        }
+    }
+
+    public void testPrivateStaticAccessorFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, true, true));  // Prevent private access
+        // Test following PR#59/PR#60 (MemberAccess support private static field).
+        try {
+          assertEquals(Ognl.getValue("privateStaticProperty", context, this), getPrivateStaticProperty());
+          fail("Should not be able to access private static property with private access turned off");
+        } catch (OgnlException oex) {
+          // Fails as test attempts to access a private accessor with private access turned off
+        }
+    }
+
+    public void testPrivateStaticFieldNormalAccessFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, true, true));  // Prevent private access
+        // Test following PR#59/PR#60 (MemberAccess support private static field).
+        try {
+            assertEquals(Ognl.getValue("_privateStaticProperty", context, this), _privateStaticProperty);
+            fail("Should not be able to access private static property with private access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a private accessor with private access turned off
+        }
+    }
+
+    public void testPrivateStaticFieldStaticAccessFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, true, true));  // Prevent private access
+        // Test following PR#59/PR#60 (MemberAccess support private static field).
+        try {
+            assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_privateStaticProperty"), _privateStaticProperty);
+            fail("Should not be able to access private static property with private access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a private accessor with private access turned off
+        }
     }
 
 	/*===================================================================


### PR DESCRIPTION
Update OGNL 3.1.x build configuration, enhance unit test and cleanup restore method.

`pom.xml` changes:
- updated `maven-surefire-plugin` 2.3 -> 2.22.1
- updated `maven-clean-plugin` 2.1.1 -> 2.6.1
- updated `junit` 4.9 -> 4.12
- updated `easymock` 2.3 -> 2.5.2
- added `defaultGoal` to build

Code changes:
- added additional tests to `PrivateMemberTest` (relevant to PR#58/PR#59/PR#60)
- minor cleanup for `DefaultMemberAccess` restore method