### PR TITLE
Update OGNL 3.2.x build configuration, enhance unit test and cleanup restore method.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.9</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>2.3</version>
+            <version>2.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -98,7 +98,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.3</version>
+                <version>2.22.1</version>  <!-- Most recent 2.x available -->
                 <configuration>
                     <excludes>
                         <exclude>**/OgnlTestCase.java</exclude>
@@ -158,9 +158,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>2.6.1</version>  <!-- Most recent 2.x available -->
             </plugin>
         </plugins>
+
+        <defaultGoal>install</defaultGoal>
+
     </build>
 
     <profiles>

--- a/src/test/java/ognl/DefaultMemberAccess.java
+++ b/src/test/java/ognl/DefaultMemberAccess.java
@@ -108,7 +108,7 @@ public class DefaultMemberAccess implements MemberAccess
         Object      result = null;
 
         if (isAccessible(context, target, member, propertyName)) {
-            AccessibleObject    accessible = (AccessibleObject)member;
+            AccessibleObject    accessible = (AccessibleObject) member;
 
             if (!accessible.isAccessible()) {
                 result = Boolean.FALSE;
@@ -121,7 +121,14 @@ public class DefaultMemberAccess implements MemberAccess
     public void restore(Map context, Object target, Member member, String propertyName, Object state)
     {
         if (state != null) {
-            ((AccessibleObject)member).setAccessible(((Boolean)state).booleanValue());
+            final AccessibleObject  accessible = (AccessibleObject) member;
+            final boolean           stateboolean = ((Boolean) state).booleanValue();  // Using twice (avoid unboxing)
+            if (!stateboolean) {
+                accessible.setAccessible(stateboolean);
+            } else {
+                throw new IllegalArgumentException("Improper restore state [" + stateboolean + "] for target [" + target +
+                                                   "], member [" + member + "], propertyName [" + propertyName + "]");
+            }
         }
     }
 


### PR DESCRIPTION
Update OGNL 3.2.x build configuration, enhance unit test and cleanup restore method.
Bring forward relevant changes from PR #61 (3.1.x)

`pom.xml` changes
- updated `maven-surefire-plugin` 2.3 -> 2.22.1
- updated `maven-clean-plugin` 2.1.1 -> 2.6.1
- updated `junit` 4.9 -> 4.12
- updated `easymock` 2.3 -> 2.5.2
- added `defaultGoal` to build

Code changes:
- added additional tests to `PrivateMemberTest` (relevant to PR#58/PR#59/PR#60)
- minor cleanup for `DefaultMemberAccess` (test-only) restore method