### PR TITLE
Updates to OGNL 3.1.x OgnlRuntime

### DIFF
--- a/src/test/java/org/ognl/test/PrivateMemberTest.java
+++ b/src/test/java/org/ognl/test/PrivateMemberTest.java
@@ -46,6 +46,8 @@ public class PrivateMemberTest extends TestCase
 {
     private static String           _privateStaticProperty = "private static value";
     private String                  _privateProperty = "private value";
+    private final String            _privateFinalProperty = "private final value";
+    private static final String     _privateStaticFinalProperty = "private static final value";
     protected OgnlContext           context;
 
 
@@ -77,6 +79,16 @@ public class PrivateMemberTest extends TestCase
         return _privateStaticProperty;
     }
 
+    private String getPrivateFinalProperty()
+    {
+        return _privateFinalProperty;
+    }
+
+    private static String getPrivateStaticFinalProperty()
+    {
+        return _privateStaticFinalProperty;
+    }
+
   /*===================================================================
     Public methods
     ===================================================================*/
@@ -88,6 +100,16 @@ public class PrivateMemberTest extends TestCase
     public void testPrivateField() throws OgnlException
     {
         assertEquals(Ognl.getValue("_privateProperty", context, this), _privateProperty);
+    }
+
+    public void testPrivateFinalAccessor() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("privateFinalProperty", context, this), getPrivateFinalProperty());
+    }
+
+    public void testPrivateFinalField() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("_privateFinalProperty", context, this), _privateFinalProperty);
     }
 
     public void testPrivateStaticAccessor() throws OgnlException
@@ -115,14 +137,129 @@ public class PrivateMemberTest extends TestCase
         // Only succeeds due to directly using the runtime to access the field as a static field.
     }
 
+    public void testPrivateStaticFinalAccessor() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("privateStaticFinalProperty", context, this), getPrivateStaticFinalProperty());
+        // Succeeds due to calling the static getter to retrieve it.
+    }
+
+    public void testPrivateStaticFinalFieldNormalAccess() throws OgnlException
+    {
+        try {
+            assertEquals(Ognl.getValue("_privateStaticFinalProperty", context, this), _privateStaticFinalProperty);
+            fail("Should not be able to access private static _privateStaticFinalProperty through getValue()");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a static field using non-static getValue
+        }
+    }
+
+    public void testPrivateStaticFinalFieldStaticAccess() throws OgnlException
+    {
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_privateStaticFinalProperty"), _privateStaticFinalProperty);
+        // Only succeeds due to directly using the runtime to access the field as a static field.
+    }
+
+    public void testPrivateFieldSet() throws OgnlException
+    {
+        final String originalValue = _privateProperty;
+        assertEquals(Ognl.getValue("_privateProperty", context, this), originalValue);
+        Ognl.setValue("_privateProperty", context, this, "changevalue");
+        assertEquals(Ognl.getValue("_privateProperty", context, this), "changevalue");
+        Ognl.setValue("_privateProperty", context, this, originalValue);
+        assertEquals(Ognl.getValue("_privateProperty", context, this), originalValue);
+    }
+
+    public void testPrivateFinalFieldSet() throws OgnlException
+    {
+        final String originalValue = _privateFinalProperty;
+        assertEquals(Ognl.getValue("_privateFinalProperty", context, this), originalValue);
+        try {
+            Ognl.setValue("_privateFinalProperty", context, this, "changevalue");
+            fail("Should not be able to modify final property");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to modify a final property
+        }
+        assertEquals(Ognl.getValue("_privateFinalProperty", context, this), originalValue);
+    }
+
+    public void testPrivateStaticFieldSet() throws OgnlException
+    {
+        final String originalValue = _privateStaticProperty;
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_privateStaticProperty"), originalValue);
+        try {
+            Ognl.setValue("_privateStaticProperty", context, this, "changevalue");
+            fail("Should not be able to modify static property");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to modify a static property
+        }
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_privateStaticProperty"), originalValue);
+    }
+
+    public void testPrivateStaticFinalFieldSet() throws OgnlException
+    {
+        final String originalValue = _privateStaticFinalProperty;
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_privateStaticFinalProperty"), originalValue);
+        try {
+            Ognl.setValue("_privateStaticFinalProperty", context, this, "changevalue");
+            fail("Should not be able to modify static property");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to modify a static property
+        }
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_privateStaticFinalProperty"), originalValue);
+    }
+
+    public void testPrivateFieldSetFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent private access
+        try {
+            Ognl.setValue("_privateProperty", context, this, "changevalue");
+            fail("Should not be able to set private property with private access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to set a private field with private access turned off
+        }
+    }
+
+    public void testPrivateFinalFieldSetFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent private access
+        try {
+            Ognl.setValue("_privateFinalProperty", context, this, "changevalue");
+            fail("Should not be able to set private property with private access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to set a private field with private access turned off
+        }
+    }
+
+    public void testPrivateStaticFieldSetFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent private access
+        try {
+            Ognl.setValue("_privateStaticProperty", context, this, "changevalue");
+            fail("Should not be able to set private property with private access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to set a private field with private access turned off
+        }
+    }
+
+    public void testPrivateStaticFinalFieldSetFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent private access
+        try {
+            Ognl.setValue("_privateStaticFinalProperty", context, this, "changevalue");
+            fail("Should not be able to set private property with private access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to set a private field with private access turned off
+        }
+    }
+
     public void testPrivateAccessorFail() throws OgnlException
     {
         context.setMemberAccess(new DefaultMemberAccess(false, true, true));  // Prevent private access
         try {
-          assertEquals(Ognl.getValue("privateProperty", context, this), getPrivateProperty());
-          fail("Should not be able to access private property with private access turned off");
+            assertEquals(Ognl.getValue("privateProperty", context, this), getPrivateProperty());
+            fail("Should not be able to access private property with private access turned off");
         } catch (OgnlException oex) {
-          // Fails as test attempts to access a private accessor with private access turned off
+            // Fails as test attempts to access a private accessor with private access turned off
         }
     }
 
@@ -130,10 +267,32 @@ public class PrivateMemberTest extends TestCase
     {
         context.setMemberAccess(new DefaultMemberAccess(false, true, true));  // Prevent private access
         try {
-          assertEquals(Ognl.getValue("_privateProperty", context, this), _privateProperty);
-          fail("Should not be able to access private property with private access turned off");
+            assertEquals(Ognl.getValue("_privateProperty", context, this), _privateProperty);
+            fail("Should not be able to access private property with private access turned off");
         } catch (OgnlException oex) {
-          // Fails as test attempts to access a private accessor with private access turned off
+            // Fails as test attempts to access a private field with private access turned off
+        }
+    }
+
+    public void testPrivateFinalAccessorFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent private access
+        try {
+            assertEquals(Ognl.getValue("privateFinalProperty", context, this), getPrivateFinalProperty());
+            fail("Should not be able to access private final property with private access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a private final accessor with private access turned off
+        }
+    }
+
+    public void testPrivateFinalFieldFail() throws OgnlException
+    {
+      context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent private access
+        try {
+            assertEquals(Ognl.getValue("_privateFinalProperty", context, this), _privateFinalProperty);
+            fail("Should not be able to access private final property with private access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a private field with private access turned off
         }
     }
 
@@ -142,10 +301,10 @@ public class PrivateMemberTest extends TestCase
         context.setMemberAccess(new DefaultMemberAccess(false, true, true));  // Prevent private access
         // Test following PR#59/PR#60 (MemberAccess support private static field).
         try {
-          assertEquals(Ognl.getValue("privateStaticProperty", context, this), getPrivateStaticProperty());
-          fail("Should not be able to access private static property with private access turned off");
+            assertEquals(Ognl.getValue("privateStaticProperty", context, this), getPrivateStaticProperty());
+            fail("Should not be able to access private static property with private access turned off");
         } catch (OgnlException oex) {
-          // Fails as test attempts to access a private accessor with private access turned off
+            // Fails as test attempts to access a private accessor with private access turned off
         }
     }
 
@@ -157,7 +316,7 @@ public class PrivateMemberTest extends TestCase
             assertEquals(Ognl.getValue("_privateStaticProperty", context, this), _privateStaticProperty);
             fail("Should not be able to access private static property with private access turned off");
         } catch (OgnlException oex) {
-            // Fails as test attempts to access a private accessor with private access turned off
+            // Fails as test attempts to access a private field with private access turned off
         }
     }
 
@@ -169,7 +328,40 @@ public class PrivateMemberTest extends TestCase
             assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_privateStaticProperty"), _privateStaticProperty);
             fail("Should not be able to access private static property with private access turned off");
         } catch (OgnlException oex) {
+            // Fails as test attempts to access a private field with private access turned off
+        }
+    }
+
+    public void testPrivateStaticFinalAccessorFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent private access
+        try {
+            assertEquals(Ognl.getValue("privateStaticFinalProperty", context, this), getPrivateStaticFinalProperty());
+            fail("Should not be able to access private static final property with private access turned off");
+        } catch (OgnlException oex) {
             // Fails as test attempts to access a private accessor with private access turned off
+        }
+    }
+
+    public void testPrivateStaticFinalFieldNormalAccessFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent private access
+        try {
+            assertEquals(Ognl.getValue("_privateStaticFinalProperty", context, this), _privateStaticFinalProperty);
+            fail("Should not be able to access private static final property with private access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a private final field with private access turned off
+        }
+    }
+
+    public void testPrivateStaticFinalFieldStaticAccessFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent private access
+        try {
+            assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_privateStaticFinalProperty"), _privateStaticFinalProperty);
+            fail("Should not be able to access private static final property with private access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a private field with private access turned off
         }
     }
 
@@ -179,6 +371,6 @@ public class PrivateMemberTest extends TestCase
 	public void setUp()
 	{
         context = (OgnlContext)Ognl.createDefaultContext(null);
-        context.setMemberAccess(new DefaultMemberAccess(true));
+        context.setMemberAccess(new DefaultMemberAccess(true, false, false));  // Permit private access, prevent protected and package access
 	}
 }

--- a/src/test/java/org/ognl/test/ProtectedMemberTest.java
+++ b/src/test/java/org/ognl/test/ProtectedMemberTest.java
@@ -1,0 +1,371 @@
+//--------------------------------------------------------------------------
+//  Copyright (c) 2004, Drew Davidson and Luke Blanshard
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//  Redistributions of source code must retain the above copyright notice,
+//  this list of conditions and the following disclaimer.
+//  Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//  Neither the name of the Drew Davidson nor the names of its contributors
+//  may be used to endorse or promote products derived from this software
+//  without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+//  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+//  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+//--------------------------------------------------------------------------
+package org.ognl.test;
+
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import ognl.DefaultMemberAccess;
+import ognl.Ognl;
+import ognl.OgnlContext;
+import ognl.OgnlException;
+import ognl.OgnlRuntime;
+
+/**
+ * This is a test program for protected access in OGNL.
+ * Shows the failures and a summary.
+ */
+public class ProtectedMemberTest extends TestCase
+{
+    protected String                _protectedProperty = "protected value";
+    protected final String          _protectedFinalProperty = "protected final value";
+    protected static String         _protectedStaticProperty = "protected static value";
+    protected static final String   _protectedStaticFinalProperty = "protected static final value";
+    protected OgnlContext           context;
+
+
+    /*===================================================================
+      Public static methods
+      ===================================================================*/
+    public static TestSuite suite()
+    {
+        return new TestSuite(ProtectedMemberTest.class);
+    }
+
+    /*===================================================================
+      Constructors
+      ===================================================================*/
+    public ProtectedMemberTest(String name)
+    {
+        super(name);
+    }
+
+    /*===================================================================
+      Protected methods
+      ===================================================================*/
+    protected String getProtectedProperty()
+    {
+        return _protectedProperty;
+    }
+
+    protected String getProtectedFinalProperty()
+    {
+        return _protectedFinalProperty;
+    }
+
+    protected static String getProtectedStaticProperty()
+    {
+        return _protectedStaticProperty;
+    }
+
+    protected static String getProtectedStaticFinalProperty()
+    {
+        return _protectedStaticFinalProperty;
+    }
+
+    /*===================================================================
+      Public methods
+      ===================================================================*/
+    public void testProtectedAccessor() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("protectedProperty", context, this), getProtectedProperty());
+    }
+
+    public void testProtectedField() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("_protectedProperty", context, this), _protectedProperty);
+    }
+
+    public void testProtectedFinalAccessor() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("protectedFinalProperty", context, this), getProtectedFinalProperty());
+    }
+
+    public void testProtectedFinalField() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("_protectedFinalProperty", context, this), _protectedFinalProperty);
+    }
+
+    public void testProtectedStaticAccessor() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("protectedStaticProperty", context, this), getProtectedStaticProperty());
+        // Succeeds due to calling the static getter to retrieve it.
+    }
+
+    public void testProtectedStaticFieldNormalAccess() throws OgnlException
+    {
+        try {
+            assertEquals(Ognl.getValue("_protectedStaticProperty", context, this), _protectedStaticProperty);
+            fail("Should not be able to access private static _protectedStaticProperty through getValue()");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a static field using non-static getValue
+        }
+    }
+
+    public void testProtectedStaticFieldStaticAccess() throws OgnlException
+    {
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_protectedStaticProperty"), _protectedStaticProperty);
+        // Only succeeds due to directly using the runtime to access the field as a static field.
+    }
+
+    public void testProtectedStaticFinalAccessor() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("protectedStaticFinalProperty", context, this), getProtectedStaticFinalProperty());
+        // Succeeds due to calling the static getter to retrieve it.
+    }
+
+    public void testProtectedStaticFinalFieldNormalAccess() throws OgnlException
+    {
+        try {
+            assertEquals(Ognl.getValue("_protectedStaticFinalProperty", context, this), _protectedStaticFinalProperty);
+            fail("Should not be able to access private static _protectedStaticFinalProperty through getValue()");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a static field using non-static getValue
+        }
+    }
+
+    public void testProtectedStaticFinalFieldStaticAccess() throws OgnlException
+    {
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_protectedStaticFinalProperty"), _protectedStaticFinalProperty);
+        // Only succeeds due to directly using the runtime to access the field as a static field.
+    }
+
+    public void testProtectedFieldSet() throws OgnlException
+    {
+        final String originalValue = _protectedProperty;
+        assertEquals(Ognl.getValue("_protectedProperty", context, this), originalValue);
+        Ognl.setValue("_protectedProperty", context, this, "changevalue");
+        assertEquals(Ognl.getValue("_protectedProperty", context, this), "changevalue");
+        Ognl.setValue("_protectedProperty", context, this, originalValue);
+        assertEquals(Ognl.getValue("_protectedProperty", context, this), originalValue);
+    }
+
+    public void testProtectedFinalFieldSet() throws OgnlException
+    {
+        final String originalValue = _protectedFinalProperty;
+        assertEquals(Ognl.getValue("_protectedFinalProperty", context, this), originalValue);
+        try {
+            Ognl.setValue("_protectedFinalProperty", context, this, "changevalue");
+            fail("Should not be able to modify final property");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to modify a final property
+        }
+        assertEquals(Ognl.getValue("_protectedFinalProperty", context, this), originalValue);
+    }
+
+    public void testProtectedStaticFieldSet() throws OgnlException
+    {
+        final String originalValue = _protectedStaticProperty;
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_protectedStaticProperty"), originalValue);
+        try {
+            Ognl.setValue("_protectedStaticProperty", context, this, "changevalue");
+            fail("Should not be able to modify static property");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to modify a static property
+        }
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_protectedStaticProperty"), originalValue);
+    }
+
+    public void testProtectedStaticFinalFieldSet() throws OgnlException
+    {
+        final String originalValue = _protectedStaticFinalProperty;
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_protectedStaticFinalProperty"), originalValue);
+        try {
+            Ognl.setValue("_protectedStaticFinalProperty", context, this, "changevalue");
+            fail("Should not be able to modify static property");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to modify a static property
+        }
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_protectedStaticFinalProperty"), originalValue);
+    }
+
+    public void testProtectedFieldSetFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            Ognl.setValue("_protectedProperty", context, this, "changevalue");
+            fail("Should not be able to set protected property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to set a protected field with protected access turned off
+        }
+    }
+
+    public void testProtectedFinalFieldSetFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            Ognl.setValue("_protectedFinalProperty", context, this, "changevalue");
+            fail("Should not be able to set protected property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to set a protected field with protected access turned off
+        }
+    }
+
+    public void testProtectedStaticFieldSetFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            Ognl.setValue("_protectedStaticProperty", context, this, "changevalue");
+            fail("Should not be able to set protected property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to set a protected field with protected access turned off
+        }
+    }
+
+    public void testProtectedStaticFinalFieldSetFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            Ognl.setValue("_protectedStaticFinalProperty", context, this, "changevalue");
+            fail("Should not be able to set protected property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to set a protected field with protected access turned off
+        }
+    }
+
+    public void testProtectedAccessorFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            assertEquals(Ognl.getValue("protectedProperty", context, this), getProtectedProperty());
+            fail("Should not be able to access protected property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a protected accessor with protected access turned off
+        }
+    }
+
+    public void testProtectedFieldFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            assertEquals(Ognl.getValue("_protectedProperty", context, this), _protectedProperty);
+            fail("Should not be able to access protected property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a protected field with protected access turned off
+        }
+    }
+
+    public void testProtectedFinalAccessorFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            assertEquals(Ognl.getValue("protectedFinalProperty", context, this), getProtectedFinalProperty());
+            fail("Should not be able to access protected final property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a protected final accessor with protected access turned off
+        }
+    }
+
+    public void testProtectedFinalFieldFail() throws OgnlException
+    {
+      context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            assertEquals(Ognl.getValue("_protectedFinalProperty", context, this), _protectedFinalProperty);
+            fail("Should not be able to access protected final property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a protected field with protected access turned off
+        }
+    }
+
+    public void testProtectedStaticAccessorFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            assertEquals(Ognl.getValue("protectedStaticProperty", context, this), getProtectedStaticProperty());
+            fail("Should not be able to access protected static property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a protected accessor with protected access turned off
+        }
+    }
+
+    public void testProtectedStaticFieldNormalAccessFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            assertEquals(Ognl.getValue("_protectedStaticProperty", context, this), _protectedStaticProperty);
+            fail("Should not be able to access protected static property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a protected field with protected access turned off
+        }
+    }
+
+    public void testProtectedStaticFieldStaticAccessFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_protectedStaticProperty"), _protectedStaticProperty);
+            fail("Should not be able to access protected static property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a protected field with protected access turned off
+        }
+    }
+
+    public void testProtectedStaticFinalAccessorFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            assertEquals(Ognl.getValue("protectedStaticFinalProperty", context, this), getProtectedStaticFinalProperty());
+            fail("Should not be able to access protected static final property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a protected accessor with protected access turned off
+        }
+    }
+
+    public void testProtectedStaticFinalFieldNormalAccessFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            assertEquals(Ognl.getValue("_protectedStaticFinalProperty", context, this), _protectedStaticFinalProperty);
+            fail("Should not be able to access protected static final property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a protected final field with protected access turned off
+        }
+    }
+
+    public void testProtectedStaticFinalFieldStaticAccessFail() throws OgnlException
+    {
+        context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent protected access
+        try {
+            assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_protectedStaticFinalProperty"), _protectedStaticFinalProperty);
+            fail("Should not be able to access protected static final property with protected access turned off");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a protected field with protected access turned off
+        }
+    }
+
+    /*===================================================================
+      Overridden methods
+      ===================================================================*/
+    public void setUp()
+    {
+          context = (OgnlContext)Ognl.createDefaultContext(null);
+          context.setMemberAccess(new DefaultMemberAccess(false, true, false));  // Permit protected access, prevent  private and package access
+    }
+}

--- a/src/test/java/org/ognl/test/PublicMemberTest.java
+++ b/src/test/java/org/ognl/test/PublicMemberTest.java
@@ -1,0 +1,210 @@
+//--------------------------------------------------------------------------
+//  Copyright (c) 2004, Drew Davidson and Luke Blanshard
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//  Redistributions of source code must retain the above copyright notice,
+//  this list of conditions and the following disclaimer.
+//  Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//  Neither the name of the Drew Davidson nor the names of its contributors
+//  may be used to endorse or promote products derived from this software
+//  without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+//  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+//  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+//--------------------------------------------------------------------------
+package org.ognl.test;
+
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import ognl.DefaultMemberAccess;
+import ognl.Ognl;
+import ognl.OgnlContext;
+import ognl.OgnlException;
+import ognl.OgnlRuntime;
+
+/**
+ * This is a test program for public access in OGNL.
+ * Shows the failures and a summary.
+ */
+public class PublicMemberTest extends TestCase
+{
+    public String                   _publicProperty = "public value";
+    public final String             _publicFinalProperty = "public final value";
+    public static String            _publicStaticProperty = "public static value";
+    public static final String      _publicStaticFinalProperty  = "public static final value";
+    protected OgnlContext           context;
+
+
+    /*===================================================================
+      Public static methods
+      ===================================================================*/
+    public static TestSuite suite()
+    {
+        return new TestSuite(PublicMemberTest.class);
+    }
+
+    /*===================================================================
+      Constructors
+      ===================================================================*/
+    public PublicMemberTest(String name)
+    {
+        super(name);
+    }
+
+    /*===================================================================
+      Public methods
+      ===================================================================*/
+    public String getPublicProperty()
+    {
+        return _publicProperty;
+    }
+
+    public String getPublicFinalProperty()
+    {
+        return _publicFinalProperty;
+    }
+
+    public static String getPublicStaticProperty()
+    {
+        return _publicStaticProperty;
+    }
+
+    public static String getPublicStaticFinalProperty()
+    {
+        return _publicStaticFinalProperty;
+    }
+
+    public void testPublicAccessor() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("publicProperty", context, this), getPublicProperty());
+    }
+
+    public void testPublicField() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("_publicProperty", context, this), _publicProperty);
+    }
+
+    public void testPublicFinalAccessor() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("publicFinalProperty", context, this), getPublicFinalProperty());
+    }
+
+    public void testPublicFinalField() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("_publicFinalProperty", context, this), _publicFinalProperty);
+    }
+
+    public void testPublicStaticAccessor() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("publicStaticProperty", context, this), getPublicStaticProperty());
+    }
+
+    public void testPublicStaticFieldNormalAccessFail() throws OgnlException
+    {
+        try {
+            assertEquals(Ognl.getValue("_publicStaticProperty", context, this), _publicStaticProperty);
+            fail("Should not be able to access public static _publicStaticProperty through getValue()");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a static field using non-static getValue
+        }
+    }
+
+    public void testPublicStaticFieldStaticAccess() throws OgnlException
+    {
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_publicStaticProperty"), _publicStaticProperty);
+    }
+
+    public void testPublicStaticFinalAccessor() throws OgnlException
+    {
+        assertEquals(Ognl.getValue("publicStaticFinalProperty", context, this), getPublicStaticFinalProperty());
+    }
+
+    public void testPublicStaticFinalFieldNormalAccessFail() throws OgnlException
+    {
+        try {
+            assertEquals(Ognl.getValue("_publicStaticFinalProperty", context, this), _publicStaticFinalProperty);
+            fail("Should not be able to access public static _publicStaticFinalProperty through getValue()");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to access a static field using non-static getValue
+        }
+    }
+
+    public void testPublicStaticFinalFieldStaticAccess() throws OgnlException
+    {
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_publicStaticFinalProperty"), _publicStaticFinalProperty);
+    }
+
+    public void testPublicFieldSet() throws OgnlException
+    {
+        final String originalValue = _publicProperty;
+        assertEquals(Ognl.getValue("_publicProperty", context, this), originalValue);
+        Ognl.setValue("_publicProperty", context, this, "changevalue");
+        assertEquals(Ognl.getValue("_publicProperty", context, this), "changevalue");
+        Ognl.setValue("_publicProperty", context, this, originalValue);
+        assertEquals(Ognl.getValue("_publicProperty", context, this), originalValue);
+    }
+
+    public void testPublicFinalFieldSet() throws OgnlException
+    {
+        final String originalValue = _publicFinalProperty;
+        assertEquals(Ognl.getValue("_publicFinalProperty", context, this), originalValue);
+        try {
+            Ognl.setValue("_publicFinalProperty", context, this, "changevalue");
+            fail("Should not be able to modify final property");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to modify a final property
+        }
+        assertEquals(Ognl.getValue("_publicFinalProperty", context, this), originalValue);
+    }
+
+    public void testPublicStaticFieldSet() throws OgnlException
+    {
+        final String originalValue = _publicStaticProperty;
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_publicStaticProperty"), originalValue);
+        try {
+            Ognl.setValue("_publicStaticProperty", context, this, "changevalue");
+            fail("Should not be able to modify static property");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to modify a static property
+        }
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_publicStaticProperty"), originalValue);
+    }
+
+    public void testPublicStaticFinalFieldSet() throws OgnlException
+    {
+        final String originalValue = _publicStaticFinalProperty;
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_publicStaticFinalProperty"), originalValue);
+        try {
+            Ognl.setValue("_publicStaticFinalProperty", context, this, "changevalue");
+            fail("Should not be able to modify static property");
+        } catch (OgnlException oex) {
+            // Fails as test attempts to modify a static property
+        }
+        assertEquals(OgnlRuntime.getStaticField(context, this.getClass().getName() , "_publicStaticFinalProperty"), originalValue);
+    }
+
+    /*===================================================================
+      Overridden methods
+      ===================================================================*/
+    public void setUp()
+    {
+          context = (OgnlContext)Ognl.createDefaultContext(null);
+          context.setMemberAccess(new DefaultMemberAccess(false, false, false));  // Prevent non-public access
+    }
+}


### PR DESCRIPTION
Updates to OGNL 3.1.x `OgnlRuntime`:

Code changes:
- added clarifying comments to `getStaticField()`, cleanup.
- added a finally guard in `invokeMethod()`.
- added a finally guard in `getFieldValue()`, cleanup.
- added additional limiter (final) to `setFieldValue()`, cleanup.
- added two test units for protected and public members.
- updated `PrivateMemberTest` with additional tests, cleanup.