### PR TITLE
Update OGNL 3.2.x to use Javassist 3.24.1 (JDK7 compatible again)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.23.1-GA</version>
+            <version>3.24.1-GA</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Update OGNL 3.2.x to use Javassist 3.24.1 (JDK7 compatible again).
Maven build completed without errors on JDK7 (1.7.0_79).