### PR TITLE
Fix backwards-compatibility issue introduced with PR#59/#60

### DIFF
--- a/src/java/ognl/ASTStaticField.java
+++ b/src/java/ognl/ASTStaticField.java
@@ -89,15 +89,21 @@ public class ASTStaticField extends SimpleNode implements NodeType
                 result = true;
             } else
             {
-                Field f = OgnlRuntime.getField(c, fieldName);
-                if (f == null) {
-                    throw new NoSuchFieldException(fieldName);
+                Field f;
+                try {
+                    f = c.getField(fieldName);  // Public fields checked first (direct)
+                } catch (NoSuchFieldException nsfe) {
+                    f = OgnlRuntime.getField(c, fieldName);  // Non-public fields checked (access controlled)
+                    if (f == null) {
+                        throw new NoSuchFieldException(fieldName);
+                    }
                 }
+                final int fModifiers = f.getModifiers();
 
-                if (!Modifier.isStatic(f.getModifiers()))
+                if (!Modifier.isStatic(fModifiers))
                     throw new OgnlException("Field " + fieldName + " of class " + className + " is not static");
 
-                result = Modifier.isFinal(f.getModifiers());
+                result = Modifier.isFinal(fModifiers);
             }
         } catch (ClassNotFoundException e) {
             reason = e;


### PR DESCRIPTION
 Fix backwards-compatibility issue introduced with PR#59/#60
 - Made access to non-public static fields _an optional opt-in feature_ (control flag via `context`).
 - Restored _original behaviour when accessing public static fields_ (the default behaviour).
 - Updated unit tests to test proper behaviour with both original (default) and opt-in behaviour.