### PR TITLE
Minor fix: Comment out missed debugging system.out.println call

### DIFF
--- a/src/java/ognl/ListPropertyAccessor.java
+++ b/src/java/ognl/ListPropertyAccessor.java
@@ -244,7 +244,7 @@ public class ListPropertyAccessor extends ObjectPropertyAccessor implements Prop
                 
                 if (m != null || !context.getCurrentType().isPrimitive())
                 {
-                    System.out.println("super source setter returned: " + super.getSourceSetter(context, target, index));
+                    // System.out.println("super source setter returned: " + super.getSourceSetter(context, target, index));
                     return super.getSourceSetter(context, target, index);
                 }
 


### PR DESCRIPTION
Minor fix:
- Comment out a system.out.println() call that appears to be
  debugging-related.
- All other system.out.println calls in OGNL are already commented out.