### PR TITLE
Proposed OGNL enhancement (alt. reflective access for JDK9+, enh. invocation control):

### DIFF
--- a/src/java/ognl/AccessibleObjectHandler.java
+++ b/src/java/ognl/AccessibleObjectHandler.java
@@ -1,0 +1,51 @@
+//--------------------------------------------------------------------------
+//	Copyright (c) 1998-2004, Drew Davidson and Luke Blanshard
+//  All rights reserved.
+//
+//	Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//	Redistributions of source code must retain the above copyright notice,
+//  this list of conditions and the following disclaimer.
+//	Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//	Neither the name of the Drew Davidson nor the names of its contributors
+//  may be used to endorse or promote products derived from this software
+//  without specific prior written permission.
+//
+//	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+//  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+//  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+//--------------------------------------------------------------------------
+package ognl;
+
+import java.lang.reflect.AccessibleObject;
+
+/**
+ * This interface provides a mechanism for indirect reflection access processing
+ *   of AccessibleObject instances by OGNL.  It can be used to provide different
+ *   behaviour as JDK reflection mechanisms evolve.
+ *
+ * @since 3.1.24
+ */
+public abstract interface AccessibleObjectHandler
+{
+    /**
+     * Provides an appropriate implementation to change the accessibility of accessibleObject.
+     *
+     * @param accessibleObject
+     * @param flag
+     */
+    void setAccessible(AccessibleObject accessibleObject, boolean flag);
+}

--- a/src/java/ognl/AccessibleObjectHandler.java
+++ b/src/java/ognl/AccessibleObjectHandler.java
@@ -1,33 +1,21 @@
-//--------------------------------------------------------------------------
-//	Copyright (c) 1998-2004, Drew Davidson and Luke Blanshard
-//  All rights reserved.
-//
-//	Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-//
-//	Redistributions of source code must retain the above copyright notice,
-//  this list of conditions and the following disclaimer.
-//	Redistributions in binary form must reproduce the above copyright
-//  notice, this list of conditions and the following disclaimer in the
-//  documentation and/or other materials provided with the distribution.
-//	Neither the name of the Drew Davidson nor the names of its contributors
-//  may be used to endorse or promote products derived from this software
-//  without specific prior written permission.
-//
-//	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-//  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-//  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-//  DAMAGE.
-//--------------------------------------------------------------------------
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * and/or LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.  The ASF licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package ognl;
 
 import java.lang.reflect.AccessibleObject;

--- a/src/java/ognl/AccessibleObjectHandlerJDK9Plus.java
+++ b/src/java/ognl/AccessibleObjectHandlerJDK9Plus.java
@@ -202,12 +202,20 @@ class AccessibleObjectHandlerJDK9Plus implements AccessibleObjectHandler
      *
      * Not intended for use outside of the package.
      *
+     * Note: An AccessibleObjectHandlerJDK9Plus will only be created if running on a
+     *   JDK9+ and the environment flag is set.  Otherwise this method will return
+     *   an AccessibleHandlerPreJDK9 instance instead,
+     *
      * @return an AccessibleObjectHandler instance
      *
      * @since 3.1.24
      */
     static AccessibleObjectHandler createHandler() {
-        return new AccessibleObjectHandlerJDK9Plus();
+        if (OgnlRuntime.usingJDK9PlusAccessHandler()){
+            return new AccessibleObjectHandlerJDK9Plus();
+        } else {
+            return AccessibleObjectHandlerPreJDK9.createHandler();
+        }
     }
 
     /**

--- a/src/java/ognl/AccessibleObjectHandlerJDK9Plus.java
+++ b/src/java/ognl/AccessibleObjectHandlerJDK9Plus.java
@@ -1,33 +1,21 @@
-//--------------------------------------------------------------------------
-//	Copyright (c) 1998-2004, Drew Davidson and Luke Blanshard
-//  All rights reserved.
-//
-//	Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-//
-//	Redistributions of source code must retain the above copyright notice,
-//  this list of conditions and the following disclaimer.
-//	Redistributions in binary form must reproduce the above copyright
-//  notice, this list of conditions and the following disclaimer in the
-//  documentation and/or other materials provided with the distribution.
-//	Neither the name of the Drew Davidson nor the names of its contributors
-//  may be used to endorse or promote products derived from this software
-//  without specific prior written permission.
-//
-//	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-//  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-//  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-//  DAMAGE.
-//--------------------------------------------------------------------------
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * and/or LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.  The ASF licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package ognl;
 
 import java.lang.reflect.AccessibleObject;
@@ -64,9 +52,9 @@ class AccessibleObjectHandlerJDK9Plus implements AccessibleObjectHandler
     private static final long _accessibleObjectOverrideFieldOffset = determineAccessibleObjectOverrideFieldOffset();
 
     /**
-     * Package-accessible constructor
+     * Private constructor
      */
-    AccessibleObjectHandlerJDK9Plus() {}
+    private AccessibleObjectHandlerJDK9Plus() {}
 
     /**
      * Package-accessible method to determine if a given class is Unsafe or a descendant
@@ -207,6 +195,19 @@ class AccessibleObjectHandlerJDK9Plus implements AccessibleObjectHandler
         }
 
         return offset;
+    }
+
+    /**
+     * Package-level generator of an AccessibleObjectHandlerJDK9Plus instance.
+     *
+     * Not intended for use outside of the package.
+     *
+     * @return an AccessibleObjectHandler instance
+     *
+     * @since 3.1.24
+     */
+    static AccessibleObjectHandler createHandler() {
+        return new AccessibleObjectHandlerJDK9Plus();
     }
 
     /**

--- a/src/java/ognl/AccessibleObjectHandlerJDK9Plus.java
+++ b/src/java/ognl/AccessibleObjectHandlerJDK9Plus.java
@@ -1,0 +1,236 @@
+//--------------------------------------------------------------------------
+//	Copyright (c) 1998-2004, Drew Davidson and Luke Blanshard
+//  All rights reserved.
+//
+//	Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//	Redistributions of source code must retain the above copyright notice,
+//  this list of conditions and the following disclaimer.
+//	Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//	Neither the name of the Drew Davidson nor the names of its contributors
+//  may be used to endorse or promote products derived from this software
+//  without specific prior written permission.
+//
+//	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+//  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+//  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+//--------------------------------------------------------------------------
+package ognl;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Utilizes a JDK 9 and later mechanism for changing the accessibility level of a given
+ *   AccessibleObject.
+ *
+ * If the JDK 9+ mechanism fails, this class will fall back to a standard pre-JDK 9 reflection mechanism.
+ *   Note:  That may cause "WARNING: Illegal reflective access" output to be generated to stdout/stderr.
+ *
+ * For reference, this class draws on information from the following locations:
+ *   - Post about Illegal Reflective Access <a href="https://stackoverflow.com/questions/50251798/what-is-an-illegal-reflective-access">what is an illegal reflective access</a>
+ *   - Blog on Unsafe <a href="http://mishadoff.com/blog/java-magic-part-4-sun-dot-misc-dot-unsafe/">Java Magic. Part 4: sun.misc.Unsafe</a>
+ *   - Blog on Unsafe <a href="https://www.baeldung.com/java-unsafe">Guide to sun.misc.Unsafe</a>
+ *   - JEP about access to Unsafe being retained in JDK 9 <a href="https://openjdk.java.net/jeps/260">JEP 260: Encapsulate Most Internal APIs</a>
+ *
+ * In addition to the above, inspiration was drawn from Gson: <a href="https://github.com/google/gson/pull/1218">PR 1218</a>,
+ *   <a href="https://github.com/google/gson/pull/1306">PR 1306</a>.
+ *
+ * Appreciation and credit to the authors, contributors and commenters for the information contained in the preceding links.
+ *
+ * @since 3.1.24
+ */
+class AccessibleObjectHandlerJDK9Plus implements AccessibleObjectHandler
+{
+    private static final Class _clazzUnsafe = instantiateClazzUnsafe();
+    private static final Object _unsafeInstance = instantiateUnsafeInstance(_clazzUnsafe);
+    private static final Method _unsafeObjectFieldOffsetMethod = instantiateUnsafeObjectFieldOffsetMethod(_clazzUnsafe);
+    private static final Method _unsafePutBooleanMethod = instantiateUnsafePutBooleanMethod(_clazzUnsafe);
+    private static final Field _accessibleObjectOverrideField = instantiateAccessibleObjectOverrideField();
+    private static final long _accessibleObjectOverrideFieldOffset = determineAccessibleObjectOverrideFieldOffset();
+
+    /**
+     * Package-accessible constructor
+     */
+    AccessibleObjectHandlerJDK9Plus() {}
+
+    /**
+     * Package-accessible method to determine if a given class is Unsafe or a descendant
+     *   of Unsafe.
+     *
+     * @param clazz
+     * @return true if parameter is Unsafe or a descendant, false otherwise
+     */
+    static boolean unsafeOrDescendant(final Class clazz) {
+        return (_clazzUnsafe != null ? _clazzUnsafe.isAssignableFrom(clazz) : false);
+    }
+
+    /**
+     * Instantiate an instance of the Unsafe class.
+     *
+     * @return class if available, null otherwise
+     */
+    private static Class instantiateClazzUnsafe() {
+        Class clazz;
+
+        try {
+            clazz = Class.forName("sun.misc.Unsafe");
+        } catch (Throwable t) {
+            clazz = null;
+        }
+
+        return clazz;
+    }
+
+    /**
+     * Instantiate an instance of Unsafe object.
+     *
+     * @param clazz (expected to be an Unsafe instance)
+     * @return instance if available, null otherwise
+     */
+    private static Object instantiateUnsafeInstance(Class clazz) {
+        Object unsafe;
+
+        if (clazz != null) {
+            Field field = null;
+            try {
+                field = clazz.getDeclaredField("theUnsafe");
+                field.setAccessible(true);
+                unsafe = field.get(null);
+            } catch (Throwable t) {
+                unsafe = null;
+            } finally {
+                if (field != null) {
+                    try {
+                        field.setAccessible(false);
+                    } catch (Throwable t) {
+                        // Don't care
+                    }
+                }
+            }
+        } else {
+            unsafe = null;
+        }
+
+        return unsafe;
+    }
+
+    /**
+     * Instantiate an Unsafe.objectFieldOffset() method instance.
+     *
+     * @param clazz (expected to be an Unsafe instance)
+     * @return method if available, null otherwise
+     */
+    private static Method instantiateUnsafeObjectFieldOffsetMethod(Class clazz) {
+        Method method;
+
+        if (clazz != null) {
+            try {
+                method = clazz.getMethod("objectFieldOffset", Field.class);
+            } catch (Throwable t) {
+                method = null;
+            }
+        } else {
+            method = null;
+        }
+
+        return method;
+    }
+
+    /**
+     * Instantiate an Unsafe.putBoolean() method instance.
+     *
+     * @param clazz (expected to be an Unsafe instance)
+     * @return method if available, null otherwise
+     */
+    private static Method instantiateUnsafePutBooleanMethod(Class clazz) {
+        Method method;
+
+        if (clazz != null) {
+            try {
+                method = clazz.getMethod("putBoolean", Object.class, long.class, boolean.class);
+            } catch (Throwable t) {
+                method = null;
+            }
+        } else {
+            method = null;
+        }
+
+        return method;
+    }
+
+    /**
+     * Instantiate an AccessibleObject override field instance.
+     *
+     * @return field if available, null otherwise
+     */
+    private static Field instantiateAccessibleObjectOverrideField() {
+        Field field;
+
+        try {
+            field = AccessibleObject.class.getDeclaredField("override");
+        } catch (Throwable t) {
+            field = null;
+        }
+
+        return field;
+    }
+
+    /**
+     * Attempt to determined the AccessibleObject override field offset.
+     *
+     * @return field offset if available, -1 otherwise
+     */
+    private static long determineAccessibleObjectOverrideFieldOffset() {
+        long offset = -1;
+
+        if (_accessibleObjectOverrideField != null && _unsafeObjectFieldOffsetMethod != null && _unsafeInstance != null) {
+            try {
+                offset = (Long) _unsafeObjectFieldOffsetMethod.invoke(_unsafeInstance, _accessibleObjectOverrideField);
+            } catch (Throwable t) {
+                // Don't care (offset already -1)
+            }
+        }
+
+        return offset;
+    }
+
+    /**
+     * Utilize accessibility modification mechanism for JDK 9 (Java Major Version 9) and later.
+     *   Should that mechanism fail, attempt a standard pre-JDK9 accessibility modification.
+     *
+     * @param accessibleObject
+     * @param flag
+     */
+    public void setAccessible(AccessibleObject accessibleObject, boolean flag) {
+        boolean operationComplete = false;
+
+        if (_unsafeInstance != null && _unsafePutBooleanMethod != null && _accessibleObjectOverrideFieldOffset != -1) {
+            try {
+                _unsafePutBooleanMethod.invoke(_unsafeInstance, accessibleObject, _accessibleObjectOverrideFieldOffset, flag);
+                operationComplete = true;
+            } catch (Throwable t) {
+                // Don't care (operationComplete already false)
+            }
+        }
+        if (!operationComplete) {
+            // Fallback to standard reflection if Unsafe processing fails
+            accessibleObject.setAccessible(flag);
+        }
+    }
+
+}

--- a/src/java/ognl/AccessibleObjectHandlerPreJDK9.java
+++ b/src/java/ognl/AccessibleObjectHandlerPreJDK9.java
@@ -1,33 +1,21 @@
-//--------------------------------------------------------------------------
-//	Copyright (c) 1998-2004, Drew Davidson and Luke Blanshard
-//  All rights reserved.
-//
-//	Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-//
-//	Redistributions of source code must retain the above copyright notice,
-//  this list of conditions and the following disclaimer.
-//	Redistributions in binary form must reproduce the above copyright
-//  notice, this list of conditions and the following disclaimer in the
-//  documentation and/or other materials provided with the distribution.
-//	Neither the name of the Drew Davidson nor the names of its contributors
-//  may be used to endorse or promote products derived from this software
-//  without specific prior written permission.
-//
-//	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-//  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-//  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-//  DAMAGE.
-//--------------------------------------------------------------------------
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * and/or LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.  The ASF licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package ognl;
 
 import java.lang.reflect.AccessibleObject;
@@ -42,9 +30,22 @@ class AccessibleObjectHandlerPreJDK9 implements AccessibleObjectHandler
 {
 
     /**
-     * Package-accessible constructor
+     * Private constructor
      */
-    AccessibleObjectHandlerPreJDK9() {}
+    private AccessibleObjectHandlerPreJDK9() {}
+
+    /**
+     * Package-level generator of an AccessibleObjectHandlerJDK9Plus instance.
+     *
+     * Not intended for use outside of the package.
+     *
+     * @return an AccessibleObjectHandler instance
+     *
+     * @since 3.1.24
+     */
+    static AccessibleObjectHandler createHandler() {
+        return new AccessibleObjectHandlerPreJDK9();
+    }
 
     /**
      * Utilize accessibility modification mechanism for JDK 8 (Java Major Version 8) and earlier.

--- a/src/java/ognl/AccessibleObjectHandlerPreJDK9.java
+++ b/src/java/ognl/AccessibleObjectHandlerPreJDK9.java
@@ -1,0 +1,59 @@
+//--------------------------------------------------------------------------
+//	Copyright (c) 1998-2004, Drew Davidson and Luke Blanshard
+//  All rights reserved.
+//
+//	Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//	Redistributions of source code must retain the above copyright notice,
+//  this list of conditions and the following disclaimer.
+//	Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//	Neither the name of the Drew Davidson nor the names of its contributors
+//  may be used to endorse or promote products derived from this software
+//  without specific prior written permission.
+//
+//	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+//  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+//  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+//--------------------------------------------------------------------------
+package ognl;
+
+import java.lang.reflect.AccessibleObject;
+
+/**
+ * Utilizes a standard pre-JDK 9 reflection mechanism for changing the accessibility level of
+ *   a given AccessibleObject.
+ *
+ * @since 3.1.24
+ */
+class AccessibleObjectHandlerPreJDK9 implements AccessibleObjectHandler
+{
+
+    /**
+     * Package-accessible constructor
+     */
+    AccessibleObjectHandlerPreJDK9() {}
+
+    /**
+     * Utilize accessibility modification mechanism for JDK 8 (Java Major Version 8) and earlier.
+     *
+     * @param accessibleObject
+     * @param flag
+     */
+    public void setAccessible(AccessibleObject accessibleObject, boolean flag) {
+        accessibleObject.setAccessible(flag);
+    }
+
+}

--- a/src/java/ognl/AccessibleObjectHandlerPreJDK9.java
+++ b/src/java/ognl/AccessibleObjectHandlerPreJDK9.java
@@ -49,6 +49,7 @@ class AccessibleObjectHandlerPreJDK9 implements AccessibleObjectHandler
 
     /**
      * Utilize accessibility modification mechanism for JDK 8 (Java Major Version 8) and earlier.
+     *   It is also the default modification mechanism for JDK 9+.
      *
      * @param accessibleObject
      * @param flag

--- a/src/java/ognl/DefaultMemberAccess.java
+++ b/src/java/ognl/DefaultMemberAccess.java
@@ -51,9 +51,11 @@ public class DefaultMemberAccess implements MemberAccess
      * Assign an accessibility modification mechanism, based on Major Java Version.
      *   Note: Can be override using a Java option flag {@link OgnlRuntime#USE_PREJDK9_ACESS_HANDLER}.
      */
-    private static final AccessibleObjectHandler _accessibleObjectHandler =
-            (OgnlRuntime.isJdk9Plus() && !OgnlRuntime.getUsePreJDK9AccessHandlerValue()) ? new AccessibleObjectHandlerJDK9Plus() :
-            new AccessibleObjectHandlerPreJDK9();
+    private static final AccessibleObjectHandler _accessibleObjectHandler;
+    static {
+        _accessibleObjectHandler = OgnlRuntime.usingJDK9PlusAccessHandler() ? AccessibleObjectHandlerJDK9Plus.createHandler() :
+            AccessibleObjectHandlerPreJDK9.createHandler();
+    }
 
     public boolean      allowPrivateAccess = false;
     public boolean      allowProtectedAccess = false;

--- a/src/java/ognl/DefaultMemberAccess.java
+++ b/src/java/ognl/DefaultMemberAccess.java
@@ -47,6 +47,14 @@ import java.util.*;
  */
 public class DefaultMemberAccess implements MemberAccess
 {
+    /*
+     * Assign an accessibility modification mechanism, based on Major Java Version.
+     *   Note: Can be override using a Java option flag {@link OgnlRuntime#USE_PREJDK9_ACESS_HANDLER}.
+     */
+    private static final AccessibleObjectHandler _accessibleObjectHandler =
+            (OgnlRuntime.isJdk9Plus() && !OgnlRuntime.getUsePreJDK9AccessHandlerValue()) ? new AccessibleObjectHandlerJDK9Plus() :
+            new AccessibleObjectHandlerPreJDK9();
+
     public boolean      allowPrivateAccess = false;
     public boolean      allowProtectedAccess = false;
     public boolean      allowPackageProtectedAccess = false;
@@ -112,7 +120,7 @@ public class DefaultMemberAccess implements MemberAccess
 
             if (!accessible.isAccessible()) {
                 result = Boolean.FALSE;
-                accessible.setAccessible(true);
+                _accessibleObjectHandler.setAccessible(accessible, true);
             }
         }
         return result;
@@ -124,7 +132,7 @@ public class DefaultMemberAccess implements MemberAccess
             final AccessibleObject  accessible = (AccessibleObject) member;
             final boolean           stateboolean = ((Boolean) state).booleanValue();  // Using twice (avoid unboxing)
             if (!stateboolean) {
-                accessible.setAccessible(stateboolean);
+                _accessibleObjectHandler.setAccessible(accessible, stateboolean);
             } else {
                 throw new IllegalArgumentException("Improper restore state [" + stateboolean + "] for target [" + target +
                                                    "], member [" + member + "], propertyName [" + propertyName + "]");

--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -191,9 +191,11 @@ public class OgnlRuntime {
      * Assign an accessibility modification mechanism, based on Major Java Version.
      *   Note: Can be override using a Java option flag {@link OgnlRuntime#USE_PREJDK9_ACESS_HANDLER}.
      */
-    private static final AccessibleObjectHandler _accessibleObjectHandler =
-            (_jdk9Plus && !_usePreJDK9AccessHandler) ? new AccessibleObjectHandlerJDK9Plus() :
-            new AccessibleObjectHandlerPreJDK9();
+    private static final AccessibleObjectHandler _accessibleObjectHandler;
+    static {
+        _accessibleObjectHandler = usingJDK9PlusAccessHandler() ? AccessibleObjectHandlerJDK9Plus.createHandler() :
+            AccessibleObjectHandlerPreJDK9.createHandler();
+    }
 
     /**
      * Private references for use in blocking direct invocation by invokeMethod().
@@ -3673,6 +3675,20 @@ public class OgnlRuntime {
      */
     public static boolean getUseStricterInvocationValue() {
         return _useStricterInvocation;
+    }
+
+    /**
+     * Returns an indication as to whether the current state indicates the
+     *   JDK9 and later access handler is being used / should be used.  This
+     *   is based on a combination of the detected Major Java Version and the
+     *   Java option flag {@link OgnlRuntime#USE_PREJDK9_ACESS_HANDLER}.
+     *
+     * @return true if the JDK9 and later access hander is being used / should be used, false otherwise.
+     *
+     * @since 3.1.24
+     */
+    public static boolean usingJDK9PlusAccessHandler() {
+        return (_jdk9Plus && !_usePreJDK9AccessHandler);
     }
 
 }

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -370,8 +370,8 @@ public class OgnlRuntimeTest {
     }
 
     /**
-     * Test OgnlRuntime value for _usePreJDK9AccessHandler based on the System property
-     *   represented by {@link OgnlRuntime#USE_PREJDK9_ACESS_HANDLER}.
+     * Test OgnlRuntime value for _useJDK9PlusAccessHandler based on the System property
+     *   represented by {@link OgnlRuntime#USE_JDK9PLUS_ACESS_HANDLER}.
      */
     @Test
     public void testAccessHanderStateFlag() {
@@ -380,7 +380,7 @@ public class OgnlRuntimeTest {
         boolean optionDefinedInEnvironment = false;  // Track if option defined in environment
         boolean flagValueFromEnvironment = false;    // Value result from environment retrieval
         try {
-            final String propertyString = System.getProperty(OgnlRuntime.USE_PREJDK9_ACESS_HANDLER);
+            final String propertyString = System.getProperty(OgnlRuntime.USE_JDK9PLUS_ACESS_HANDLER);
             if (propertyString != null && propertyString.length() > 0) {
                 optionDefinedInEnvironment = true;
                 flagValueFromEnvironment = Boolean.parseBoolean(propertyString);
@@ -389,13 +389,13 @@ public class OgnlRuntimeTest {
             // Unavailable (SecurityException, etc.)
         }
         if (optionDefinedInEnvironment) {
-            System.out.println("System property " + OgnlRuntime.USE_PREJDK9_ACESS_HANDLER + " value: " + flagValueFromEnvironment);
+            System.out.println("System property " + OgnlRuntime.USE_JDK9PLUS_ACESS_HANDLER + " value: " + flagValueFromEnvironment);
         } else {
-            System.out.println("System property " + OgnlRuntime.USE_PREJDK9_ACESS_HANDLER + " not present.  Default value should be: " + defaultValue);
+            System.out.println("System property " + OgnlRuntime.USE_JDK9PLUS_ACESS_HANDLER + " not present.  Default value should be: " + defaultValue);
         }
-        System.out.println("Current OGNL value for use pre-JDK9 Access Handler: " + OgnlRuntime.getUsePreJDK9AccessHandlerValue());
-        Assert.assertEquals("Mismatch between system property (or default) and OgnlRuntime _usePreJDK9AccessHandler flag state ?",
-                optionDefinedInEnvironment ? flagValueFromEnvironment : defaultValue, OgnlRuntime.getUsePreJDK9AccessHandlerValue());
+        System.out.println("Current OGNL value for use JDK9+ Access Handler: " + OgnlRuntime.getUseJDK9PlusAccessHandlerValue());
+        Assert.assertEquals("Mismatch between system property (or default) and OgnlRuntime _usJDK9PlusAccessHandler flag state ?",
+                optionDefinedInEnvironment ? flagValueFromEnvironment : defaultValue, OgnlRuntime.getUseJDK9PlusAccessHandlerValue());
     }
 
     /**

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -316,4 +316,159 @@ public class OgnlRuntimeTest {
                     (cumulativelRunTestElapsedNanoTime / (1000 * 1000 * 1000)) / totalNumberOfRunTestRuns + " s)");
         }
     }
+
+    /**
+     * Test OgnlRuntime version parsing mechanism.
+     */
+    @Test
+    public void testMajorJavaVersionParse() {
+        // Pre-JDK 9 version strings.
+        Assert.assertEquals("JDK 5 version check failed ?", 5, OgnlRuntime.parseMajorJavaVersion("1.5"));
+        Assert.assertEquals("JDK 5 version check failed ?", 5, OgnlRuntime.parseMajorJavaVersion("1.5.0"));
+        Assert.assertEquals("JDK 5 version check failed ?", 5, OgnlRuntime.parseMajorJavaVersion("1.5.0_21-b11"));
+        Assert.assertEquals("JDK 6 version check failed ?", 6, OgnlRuntime.parseMajorJavaVersion("1.6"));
+        Assert.assertEquals("JDK 6 version check failed ?", 6, OgnlRuntime.parseMajorJavaVersion("1.6.0"));
+        Assert.assertEquals("JDK 6 version check failed ?", 6, OgnlRuntime.parseMajorJavaVersion("1.6.0_43-b19"));
+        Assert.assertEquals("JDK 7 version check failed ?", 7, OgnlRuntime.parseMajorJavaVersion("1.7"));
+        Assert.assertEquals("JDK 7 version check failed ?", 7, OgnlRuntime.parseMajorJavaVersion("1.7.0"));
+        Assert.assertEquals("JDK 7 version check failed ?", 7, OgnlRuntime.parseMajorJavaVersion("1.7.0_79-b15"));
+        Assert.assertEquals("JDK 8 version check failed ?", 8, OgnlRuntime.parseMajorJavaVersion("1.8"));
+        Assert.assertEquals("JDK 8 version check failed ?", 8, OgnlRuntime.parseMajorJavaVersion("1.8.0"));
+        Assert.assertEquals("JDK 8 version check failed ?", 8, OgnlRuntime.parseMajorJavaVersion("1.8.0_201-b20"));
+        Assert.assertEquals("JDK 8 version check failed ?", 8, OgnlRuntime.parseMajorJavaVersion("1.8.0-someopenjdkstyle"));
+        Assert.assertEquals("JDK 8 version check failed ?", 8, OgnlRuntime.parseMajorJavaVersion("1.8.0_201-someopenjdkstyle"));
+        // JDK 9 and later version strings.
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9"));
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9-ea+19"));
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9+100"));
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9-ea+19"));
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9.1.3+15"));
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9-someopenjdkstyle"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10-ea+11"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10+10"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10-ea+11"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10.1.3+15"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10-someopenjdkstyle"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11-ea+22"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11+33"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11-ea+19"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11.1.3+15"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11-someopenjdkstyle"));
+    }
+
+    /**
+     * Test OgnlRuntime Major Version Check mechanism.
+     */
+    @Test
+    public void testMajorJavaVersionCheck() {
+        // Ensure no exceptions, basic ouput for test report and sanity check on minimum version.
+        final int majorJavaVersion = OgnlRuntime.detectMajorJavaVersion();
+        System.out.println("Major Java Version detected: " + majorJavaVersion);
+        Assert.assertTrue("Major Java Version Check returned value (" + majorJavaVersion + ") less than minimum (5) ?", majorJavaVersion >= 5);
+    }
+
+    /**
+     * Test OgnlRuntime value for _usePreJDK9AccessHandler based on the System property
+     *   represented by {@link OgnlRuntime#USE_PREJDK9_ACESS_HANDLER}.
+     */
+    @Test
+    public void testAccessHanderStateFlag() {
+        // Ensure no exceptions, basic ouput for test report and sanity check on flag state.
+        final boolean defaultValue = false;          // Expected non-configured default
+        boolean optionDefinedInEnvironment = false;  // Track if option defined in environment
+        boolean flagValueFromEnvironment = false;    // Value result from environment retrieval
+        try {
+            final String propertyString = System.getProperty(OgnlRuntime.USE_PREJDK9_ACESS_HANDLER);
+            if (propertyString != null && propertyString.length() > 0) {
+                optionDefinedInEnvironment = true;
+                flagValueFromEnvironment = Boolean.parseBoolean(propertyString);
+            }
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        if (optionDefinedInEnvironment) {
+            System.out.println("System property " + OgnlRuntime.USE_PREJDK9_ACESS_HANDLER + " value: " + flagValueFromEnvironment);
+        } else {
+            System.out.println("System property " + OgnlRuntime.USE_PREJDK9_ACESS_HANDLER + " not present.  Default value should be: " + defaultValue);
+        }
+        System.out.println("Current OGNL value for use pre-JDK9 Access Handler: " + OgnlRuntime.getUsePreJDK9AccessHandlerValue());
+        Assert.assertEquals("Mismatch between system property (or default) and OgnlRuntime _usePreJDK9AccessHandler flag state ?",
+                optionDefinedInEnvironment ? flagValueFromEnvironment : defaultValue, OgnlRuntime.getUsePreJDK9AccessHandlerValue());
+    }
+
+    /**
+     * Test OgnlRuntime value for _useStricterInvocation based on the System properties
+     *   represented by {@link OgnlRuntime#USE_STRICTER_INVOCATION}.
+     */
+    @Test
+    public void testUseStricterInvocationStateFlag() {
+        // Ensure no exceptions, basic ouput for test report and sanity check on flag state.
+        final boolean defaultValue = true;           // Expected non-configured default
+        boolean optionDefinedInEnvironment = false;  // Track if option defined in environment
+        boolean flagValueFromEnvironment = true;     // Expected non-configured default
+        try {
+            final String propertyString = System.getProperty(OgnlRuntime.USE_STRICTER_INVOCATION);
+            if (propertyString != null && propertyString.length() > 0) {
+                optionDefinedInEnvironment = true;
+                flagValueFromEnvironment = Boolean.parseBoolean(propertyString);
+            }
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        if (optionDefinedInEnvironment) {
+            System.out.println("System property " + OgnlRuntime.USE_STRICTER_INVOCATION + " value: " + flagValueFromEnvironment);
+        } else {
+            System.out.println("System property " + OgnlRuntime.USE_STRICTER_INVOCATION + " not present.  Default value should be: " + defaultValue);
+        }
+        System.out.println("Current OGNL value for use stricter invocation: " + OgnlRuntime.getUseStricterInvocationValue());
+        Assert.assertEquals("Mismatch between system property (or default) and OgnlRuntime _useStricterInvocation flag state ?",
+                optionDefinedInEnvironment ? flagValueFromEnvironment : defaultValue, OgnlRuntime.getUseStricterInvocationValue());
+    }
+
+    /**
+     * Test OgnlRuntime stricter invocation mode.
+     */
+    @Test
+    public void testStricterInvocationMode() {
+        // Ensure no exceptions, basic ouput for test report and sanity check on flag state.
+        // Note: If stricter invocation mode is disabled (due to a system property being set for
+        //   the JVM running the test) this test will not fail, but just skip the test.
+        if ( OgnlRuntime.getUseStricterInvocationValue()) {
+            try {
+                final Class<?>[] singleClassArgument = new Class<?>[1];
+                singleClassArgument[0] = int.class;
+                final Method exitMethod = System.class.getMethod("exit", singleClassArgument);
+                try {
+                    OgnlRuntime.invokeMethod(System.class, exitMethod, new Object[] { -1 });
+                    Assert.fail("Somehow got past invocation of a restricted exit call (nonsensical result) ?");
+                } catch (IllegalAccessException iae) {
+                    // Expected failure (failed during invocation)
+                    System.out.println("Stricter invocation mode blocked restricted call (as expected).  Exception: " + iae);
+                } catch (SecurityException se) {
+                    // Possible exception if test is run with an active security manager)
+                    System.out.println("Stricter invocation mode blocked by security manager (may be valid).  Exception: " + se);
+                }
+
+                singleClassArgument[0] = String.class;
+                final Method execMethod = Runtime.class.getMethod("exec", singleClassArgument);
+                try {
+                    OgnlRuntime.invokeMethod(Runtime.getRuntime(), execMethod, new Object[] { "fakeCommand" });
+                    Assert.fail("Somehow got past invocation of a restricted exec call ?");
+                } catch (IllegalAccessException iae) {
+                    // Expected failure (failed during invocation)
+                    System.out.println("Stricter invocation mode blocked restricted call (as expected).  Exception: " + iae);
+                } catch (SecurityException se) {
+                    // Possible exception if test is run with an active security manager)
+                    System.out.println("Stricter invocation mode blocked by security manager (may be valid).  Exception: " + se);
+                }
+            } catch (Exception ex) {
+                Assert.fail("Unable to fully test stricter invocation mode.  Exception: " + ex);
+            }
+        } else {
+            System.out.println("Not testing stricter invocation mode (disabled via system property).");
+        }
+    }
+
 }

--- a/src/test/java/ognl/TestOgnlRuntime.java
+++ b/src/test/java/ognl/TestOgnlRuntime.java
@@ -180,6 +180,11 @@ public class TestOgnlRuntime extends TestCase {
 
     public void test_Call_Method_In_JDK_Sandbox()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Call_Method_In_JDK_Sandbox() -invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null);
         GenericService service = new GenericServiceImpl();
 
@@ -188,7 +193,7 @@ public class TestOgnlRuntime extends TestCase {
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -202,19 +207,24 @@ public class TestOgnlRuntime extends TestCase {
             assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("execute"));
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }
 
     public void test_Call_Method_In_JDK_Sandbox_Thread_Safety()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Call_Method_In_JDK_Sandbox_Thread_Safety() invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         final OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null);
         final GenericService service = new GenericServiceImpl();
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -269,13 +279,18 @@ public class TestOgnlRuntime extends TestCase {
             assertEquals(0, numThreadsFailedTest.get());
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }
 
     public void test_Disable_JDK_Sandbox()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Disable_JDK_Sandbox() invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null);
         GenericService service = new GenericServiceImpl();
 
@@ -283,7 +298,7 @@ public class TestOgnlRuntime extends TestCase {
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -294,17 +309,17 @@ public class TestOgnlRuntime extends TestCase {
             fail("JDK sandbox should block execution");
         } catch (Exception ex) {
             assertTrue(ex.getCause() instanceof InvocationTargetException);
-            assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("ognl.security.manager"));
+            assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains(OgnlRuntime.OGNL_SECURITY_MANAGER));
             assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("write"));
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
 
         temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -317,13 +332,13 @@ public class TestOgnlRuntime extends TestCase {
             assertTrue(ex.getCause().getMessage().contains("accessDeclaredMembers"));
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
 
         temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -338,13 +353,18 @@ public class TestOgnlRuntime extends TestCase {
             assertNull(((InvocationTargetException)ex.getCause()).getTargetException().getMessage());
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }
 
     public void test_Exit_JDK_Sandbox()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Exit_JDK_Sandbox() invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null);
         GenericService service = new GenericServiceImpl();
 
@@ -352,7 +372,7 @@ public class TestOgnlRuntime extends TestCase {
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -366,13 +386,18 @@ public class TestOgnlRuntime extends TestCase {
             assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("exit"));
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }
 
     public void test_Call_Method_In_JDK_Sandbox_Privileged()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Call_Method_In_JDK_Sandbox_Privileged() invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null);
         GenericService service = new GenericServiceImpl();
 
@@ -380,7 +405,7 @@ public class TestOgnlRuntime extends TestCase {
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -396,13 +421,13 @@ public class TestOgnlRuntime extends TestCase {
             assertTrue(ex.getCause().getMessage().contains("test.properties"));
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
 
         temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -414,13 +439,18 @@ public class TestOgnlRuntime extends TestCase {
             assertNotSame(-1, result);
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }
 
     public void test_Class_Loader_Direct_Access()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Class_Loader_Direct_Access() invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null);
         ClassLoader classLoader = getClass().getClassLoader();
 
@@ -429,7 +459,7 @@ public class TestOgnlRuntime extends TestCase {
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -440,10 +470,17 @@ public class TestOgnlRuntime extends TestCase {
             fail("JDK sandbox should block execution");
         } catch (Exception ex) {
             assertTrue(ex.getCause() instanceof IllegalAccessException);
-            assertEquals("OGNL direct access to class loader denied!", ex.getCause().getMessage());
+            if (OgnlRuntime.getUseStricterInvocationValue() == true) {
+                // Blocked by stricter invocation check first, if active.
+                assertTrue("Didn't find expected stricter invocation mode exception message ?",
+                        ex.getCause().getMessage().endsWith("] cannot be called from within OGNL invokeMethod() under stricter invocation mode."));
+            } else {
+                // Otherwise, blocked by OGNL SecurityManager sandbox.
+                assertEquals("OGNL direct access to class loader denied!", ex.getCause().getMessage());
+            }
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }

--- a/src/test/java/org/ognl/test/objects/GenericServiceImpl.java
+++ b/src/test/java/org/ognl/test/objects/GenericServiceImpl.java
@@ -9,6 +9,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.*;
 import java.util.List;
+import ognl.OgnlRuntime;
 
 /**
  *
@@ -28,6 +29,9 @@ public class GenericServiceImpl implements GenericService {
     }
 
     public void exec(long sleepMilliseconds) throws InterruptedException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         Thread.sleep(sleepMilliseconds);
         Object runtime = Runtime.class.getMethod("getRuntime").invoke(null);
         Object process = Runtime.class.getMethod("exec", String.class).invoke(runtime, "time");
@@ -35,11 +39,17 @@ public class GenericServiceImpl implements GenericService {
     }
 
     public void disableSandboxViaReflectionByProperty() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         Method clearPropertyMethod = System.class.getMethod("clearProperty", String.class);
         clearPropertyMethod.invoke(null, "ognl.security.manager");
     }
 
     public void disableSandboxViaReflectionByField() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException, NoSuchFieldException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         Method getOgnlSecurityManagerMethod = OgnlSecurityManagerFactory.class.getMethod("getOgnlSecurityManager");
         Object ognlSecurityManager = getOgnlSecurityManagerMethod.invoke(null);
         Field residentsField = ognlSecurityManager.getClass().getDeclaredField("residents");
@@ -53,6 +63,9 @@ public class GenericServiceImpl implements GenericService {
     }
 
     public void disableSandboxViaReflectionByMethod() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         Method getOgnlSecurityManagerMethod = OgnlSecurityManagerFactory.class.getMethod("getOgnlSecurityManager");
         Object ognlSecurityManager = getOgnlSecurityManagerMethod.invoke(null);
         SecureRandom rnd = new SecureRandom();
@@ -60,10 +73,16 @@ public class GenericServiceImpl implements GenericService {
     }
 
     public void exit() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         System.class.getMethod("exit", int.class).invoke(null, 0);
     }
 
     public int doNotPrivileged() throws IOException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         InputStream is = getClass().getClassLoader().getResource("test.properties").openStream();
         int result = is.read();
         is.close();
@@ -71,6 +90,9 @@ public class GenericServiceImpl implements GenericService {
     }
 
     public int doPrivileged() throws IOException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         InputStream is = null;
         try {
             is = AccessController.doPrivileged(new PrivilegedExceptionAction<InputStream>() {


### PR DESCRIPTION
Proposed OGNL enhancement:
- Implement mechanism to avoid "Illegal Reflective Access" warnings in JDK9+, with fallback to normal reflection.  Users can force usage of normal reflection in JDK9+ using a Java option (environment) flag if needed.
- Add interface to decouple AccessibleObject processing (easier support for future Java reflection changes).
- Add mechanism to check for JDK version (allows decision on access mechanism to use).
- Implement a stricter invocation mechanism by default to limit certain invocations.  Users can disable the stricter invocation using a Java option (environment) flag if needed.
- Adds additional unit tests for the changes (insofar as they can be tested).