### PR TITLE
OGNL improve getter/setter detection algorithm:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,12 @@
 
         <plugins>
             <plugin>
+                <!-- Raised source/target levels to 1.6 as Travis CI now rejects 1.5 -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
                 <executions>
                     <execution>
@@ -92,8 +93,8 @@
                             <goal>testCompile</goal>
                         </goals>
                         <configuration>
-                            <source>1.5</source>
-                            <target>1.5</target>
+                            <source>1.6</source>
+                            <target>1.6</target>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -2410,12 +2410,10 @@ public class OgnlRuntime {
                     }
                     if (firstPublicGetter == null && Modifier.isPublic(m.getModifiers()) && declaringClassIsPublic) {
                         firstPublicGetter = m;
+                        break;  // Stop looking (this is the best possible match)
                     }
                     if (firstNonDefaultPublicInterfaceGetter == null && isNonDefaultPublicInterfaceMethod(m) && declaringClassIsPublic) {
                         firstNonDefaultPublicInterfaceGetter = m;
-                    }
-                    if (firstGetter != null && firstPublicGetter != null && firstNonDefaultPublicInterfaceGetter != null) {
-                        break;
                     }
                 }
             }
@@ -2502,12 +2500,10 @@ public class OgnlRuntime {
                     }
                     if (firstPublicSetter == null && Modifier.isPublic(m.getModifiers()) && declaringClassIsPublic) {
                         firstPublicSetter = m;
+                        break;  // Stop looking (this is the best possible match)
                     }
                     if (firstNonDefaultPublicInterfaceSetter == null && isNonDefaultPublicInterfaceMethod(m) && declaringClassIsPublic) {
                         firstNonDefaultPublicInterfaceSetter = m;
-                    }
-                    if (firstSetter != null && firstPublicSetter != null && firstNonDefaultPublicInterfaceSetter != null) {
-                        break;
                     }
                 }
             }

--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -1922,7 +1922,7 @@ public class OgnlRuntime {
      *
      * @return true If method qualifies as a non-Default public Interface method, false otherwise.
      *
-     * @since 3.1.24
+     * @since 3.1.25
      */
     private static boolean isNonDefaultPublicInterfaceMethod(Method method) {
         return ((method.getModifiers()
@@ -2368,7 +2368,7 @@ public class OgnlRuntime {
     /**
      * Returns a qualifying get (getter) method, if one is available for the given targetClass and propertyName.
      *
-     * Note: From OGNL 3.1.24 onward, this method will attempt to find the first get getter method(s) that match:
+     * Note: From OGNL 3.1.25 onward, this method will attempt to find the first get getter method(s) that match:
      *         1) First get (getter) method, whether public or not.
      *         2) First public get (getter) method, provided the method's declaring class is also public.
      *            This may be the same as 1), if 1) is also public and its declaring class is also public.
@@ -2461,7 +2461,7 @@ public class OgnlRuntime {
     /**
      * Returns a qualifying set (setter) method, if one is available for the given targetClass and propertyName.
      *
-     * Note: From OGNL 3.1.24 onward, this method will attempt to find the first set setter method(s) that match:
+     * Note: From OGNL 3.1.25 onward, this method will attempt to find the first set setter method(s) that match:
      *         1) First set (setter) method, whether public or not.
      *         2) First public set (setter) method, provided the method's declaring class is also public.
      *            This may be the same as 1), if 1) is also public and its declaring class is also public.

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -316,4 +316,34 @@ public class OgnlRuntimeTest {
                     (cumulativelRunTestElapsedNanoTime / (1000 * 1000 * 1000)) / totalNumberOfRunTestRuns + " s)");
         }
     }
+
+    /**
+     * Test OgnlRuntime value for _useFirstMatchGetSetLookup based on the System property
+     *   represented by {@link OgnlRuntime#USE_FIRSTMATCH_GETSET_LOOKUP}.
+     */
+    @Test
+    public void testUseFirstMatchGetSetStateFlag() {
+        // Ensure no exceptions, basic ouput for test report and sanity check on flag state.
+        final boolean defaultValue = false;          // Expected non-configured default
+        boolean optionDefinedInEnvironment = false;  // Track if option defined in environment
+        boolean flagValueFromEnvironment = false;    // Value result from environment retrieval
+        try {
+            final String propertyString = System.getProperty(OgnlRuntime.USE_FIRSTMATCH_GETSET_LOOKUP);
+            if (propertyString != null && propertyString.length() > 0) {
+                optionDefinedInEnvironment = true;
+                flagValueFromEnvironment = Boolean.parseBoolean(propertyString);
+            }
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        if (optionDefinedInEnvironment) {
+            System.out.println("System property " + OgnlRuntime.USE_FIRSTMATCH_GETSET_LOOKUP + " value: " + flagValueFromEnvironment);
+        } else {
+            System.out.println("System property " + OgnlRuntime.USE_FIRSTMATCH_GETSET_LOOKUP + " not present.  Default value should be: " + defaultValue);
+        }
+        System.out.println("Current OGNL value for Use First Match Get/Set State Flag: " + OgnlRuntime.getUseFirstMatchGetSetLookupValue());
+        Assert.assertEquals("Mismatch between system property (or default) and OgnlRuntime _useFirstMatchGetSetLookup flag state ?",
+                optionDefinedInEnvironment ? flagValueFromEnvironment : defaultValue, OgnlRuntime.getUseFirstMatchGetSetLookupValue());
+    }
+
 }


### PR DESCRIPTION
OGNL improve getter/setter detection algorithm:
- Add detail to isDefaultMethod() method comment.
- Add a new isNonDefaultPublicInterfaceMethod() method.
- Modify collectAccessors() method to consider public interface methods in addition to default methods.
- Modify _getGetMethod() to prefer the first valid public getter over other getters, then the first valid public non-Default interface getter and lastly the first getter of any kind.
- Modify _getSetMethod() to prefer the first valid public setter over other setters, then the first valid public non-Default interface setter and lastly the first setter of any kind.