### PR TITLE
Compare non-comparable objects by equals only

### DIFF
--- a/src/main/java/ognl/OgnlOps.java
+++ b/src/main/java/ognl/OgnlOps.java
@@ -145,7 +145,7 @@ public abstract class OgnlOps implements NumericTypes
                 int t2 = getNumericType(object2);
 
                 // compare non-comparable non-numeric types by equals only
-                if (t1 == NONNUMERIC && t2 == NONNUMERIC && !(object1 instanceof Comparable)) {
+                if (t1 == NONNUMERIC && t2 == NONNUMERIC && (!(object1 instanceof Comparable) || !(object2 instanceof Comparable))) {
                     result = object1.equals(object2);
                 } else {
                     result = compareWithConversion(object1, object2) == 0;

--- a/src/main/java/ognl/OgnlOps.java
+++ b/src/main/java/ognl/OgnlOps.java
@@ -128,9 +128,11 @@ public abstract class OgnlOps implements NumericTypes
 
         if (object1 == object2) {
             result = true;
+        } else if (object1 == null || object2 == null) {
+            result = false;
         } else {
-            if ((object1 != null) && object1.getClass().isArray()) {
-                if ((object2 != null) && object2.getClass().isArray() && (object2.getClass() == object1.getClass())) {
+            if (object1.getClass().isArray()) {
+                if (object2.getClass().isArray() && (object2.getClass() == object1.getClass())) {
                     result = (Array.getLength(object1) == Array.getLength(object2));
                     if (result) {
                         for(int i = 0, icount = Array.getLength(object1); result && (i < icount); i++) {
@@ -139,9 +141,15 @@ public abstract class OgnlOps implements NumericTypes
                     }
                 }
             } else {
-                // Check for converted equivalence first, then equals() equivalence
-                result = (object1 != null) && (object2 != null)
-                        && (object1.equals(object2) || (compareWithConversion(object1, object2) == 0));
+                int t1 = getNumericType(object1);
+                int t2 = getNumericType(object2);
+
+                // compare non-comparable non-numeric types by equals only
+                if (t1 == NONNUMERIC && t2 == NONNUMERIC && !(object1 instanceof Comparable)) {
+                    result = object1.equals(object2);
+                } else {
+                    result = compareWithConversion(object1, object2) == 0;
+                }
             }
         }
         return result;

--- a/src/main/java/ognl/OgnlOps.java
+++ b/src/main/java/ognl/OgnlOps.java
@@ -128,9 +128,7 @@ public abstract class OgnlOps implements NumericTypes
 
         if (object1 == object2) {
             result = true;
-        } else if (object1 == null || object2 == null) {
-            result = false;
-        } else {
+        } else if (object1 != null && object2 != null) {
             if (object1.getClass().isArray()) {
                 if (object2.getClass().isArray() && (object2.getClass() == object1.getClass())) {
                     result = (Array.getLength(object1) == Array.getLength(object2));

--- a/src/test/java/org/ognl/test/ArithmeticAndLogicalOperatorsTest.java
+++ b/src/test/java/org/ognl/test/ArithmeticAndLogicalOperatorsTest.java
@@ -137,6 +137,10 @@ public class ArithmeticAndLogicalOperatorsTest extends OgnlTestCase
             { "1 shl 2", new Integer(4) }, { "4 shr 2", new Integer(1) }, { "4 ushr 2", new Integer(1) },
             { "not null", Boolean.TRUE }, { "not 1", Boolean.FALSE },
 
+            // Equality on identity; Object does not implement Comparable
+            { "#a = new java.lang.Object(), #a == #a", Boolean.TRUE},
+            { "#a = new java.lang.Object(), #b = new java.lang.Object(), #a == #b", Boolean.FALSE},
+
             { "#x > 0", Boolean.TRUE },
             { "#x < 0", Boolean.FALSE },
             { "#x == 0", Boolean.FALSE },

--- a/src/test/java/org/ognl/test/ArithmeticAndLogicalOperatorsTest.java
+++ b/src/test/java/org/ognl/test/ArithmeticAndLogicalOperatorsTest.java
@@ -141,6 +141,10 @@ public class ArithmeticAndLogicalOperatorsTest extends OgnlTestCase
             { "#a = new java.lang.Object(), #a == #a", Boolean.TRUE},
             { "#a = new java.lang.Object(), #b = new java.lang.Object(), #a == #b", Boolean.FALSE},
 
+            // Comparable and non-Comparable
+            { "#a = new java.lang.Object(), #a == ''", Boolean.FALSE},
+            { "#a = new java.lang.Object(), '' == #a", Boolean.FALSE},
+
             { "#x > 0", Boolean.TRUE },
             { "#x < 0", Boolean.FALSE },
             { "#x == 0", Boolean.FALSE },


### PR DESCRIPTION
When comparing non-numeric objects that do not implement `Comparable` interface, OGNL would throw an exception if they are not equal (so `a == b` is either true or an exception for these objects)
https://github.com/jkuhnert/ognl/blob/master/src/main/java/ognl/OgnlOps.java#L93

e.g.

```java
    Map<String, Object> map = new HashMap<String, Object>();
    map.put("a", new Object());
    map.put("b", new Object());

    // same object, result is true
    assertTrue((Boolean)Ognl.getValue("a == a", map));
    // different object, throws an exception instead of returning false
    assertFalse((Boolean)Ognl.getValue("a == b", map));
```

This PR addresses that.

Note that it doesn't make sense to make the check inside `OgnlOps::compareWithConversion`, because that method is used by `OgnlOps::less`, in which case it still makes sense to throw up. (because `a < b` on non-comparable objects doesn't make sense).