### PR TITLE
not fail on getDeclaredXXX when user has used a SecurityManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
                 <executions>
                     <execution>
@@ -92,8 +92,8 @@
                             <goal>testCompile</goal>
                         </goals>
                         <configuration>
-                            <source>1.5</source>
-                            <target>1.5</target>
+                            <source>1.6</source>
+                            <target>1.6</target>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -2274,7 +2274,7 @@ public class OgnlRuntime {
     private static void collectAccessors(Class c, String baseName, List result, boolean findSets)
     {
         Method[] methods;
-        try{
+        try {
             methods = c.getDeclaredMethods();
         } catch (SecurityException ignored) {
             methods = c.getMethods();

--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -1861,7 +1861,12 @@ public class OgnlRuntime {
     }
 
     private static void collectMethods(Class c, Map result, boolean staticMethods) {
-        Method[] ma = c.getDeclaredMethods();
+        Method[] ma;
+        try {
+            ma = c.getDeclaredMethods();
+        } catch (SecurityException ignored) {
+            ma = c.getMethods();
+        }
         for (int i = 0, icount = ma.length; i < icount; i++)
         {
             if (c.isInterface())
@@ -1966,7 +1971,11 @@ public class OgnlRuntime {
                     Field fa[];
 
                     result = new HashMap(23);
-                    fa = targetClass.getDeclaredFields();
+                    try {
+                        fa = targetClass.getDeclaredFields();
+                    } catch (SecurityException ignored) {
+                        fa = targetClass.getFields();
+                    }
                     for (int i = 0; i < fa.length; i++) {
                         result.put(fa[i].getName(), fa[i]);
                     }
@@ -2264,7 +2273,12 @@ public class OgnlRuntime {
 
     private static void collectAccessors(Class c, String baseName, List result, boolean findSets)
     {
-        final Method[] methods = c.getDeclaredMethods();
+        Method[] methods;
+        try{
+            methods = c.getDeclaredMethods();
+        } catch (SecurityException ignored) {
+            methods = c.getMethods();
+        }
         for (int i = 0; i < methods.length; i++) {
             if (c.isInterface()) {
                 if (isDefaultMethod(methods[i])) {


### PR DESCRIPTION
Falls back to getXXX on SecurityException to be more adaptable for environments that have a SecurityManager applied.