### PR TITLE
Forward-port PR#77 from 3.1.x to 3.2.x (cherry-pick)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,9 @@
                     <archive>
                         <compress>true</compress>
                         <index>true</index>
+                        <manifestEntries>
+                            <Automatic-Module-Name>ognl</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -363,19 +363,63 @@ public class OgnlRuntime {
      */
     public static void clearCache()
     {
-        _methodParameterTypesCache.clear();
-        _ctorParameterTypesCache.clear();
-        _propertyDescriptorCache.clear();
-        _constructorCache.clear();
-        _staticMethodCache.clear();
-        _instanceMethodCache.clear();
-        _invokePermissionCache.clear();
-        _fieldCache.clear();
-        _superclasses.clear();
-        _declaredMethods[0].clear();
-        _declaredMethods[1].clear();
+        synchronized(_methodParameterTypesCache) {
+            _methodParameterTypesCache.clear();
+        }
+        synchronized(_ctorParameterTypesCache) {
+            _ctorParameterTypesCache.clear();
+        }
+        synchronized(_propertyDescriptorCache) {
+            _propertyDescriptorCache.clear();
+        }
+        synchronized(_constructorCache) {
+            _constructorCache.clear();
+        }
+        synchronized(_staticMethodCache) {
+            _staticMethodCache.clear();
+        }
+        synchronized(_instanceMethodCache) {
+            _instanceMethodCache.clear();
+        }
+        synchronized(_invokePermissionCache) {
+            _invokePermissionCache.clear();
+        }
+        synchronized(_fieldCache) {
+            _fieldCache.clear();
+            _superclasses.clear();  // Used by fieldCache lookup (synchronized on _fieldCache).
+        }
+        synchronized(_declaredMethods[0]) {
+            _declaredMethods[0].clear();
+        }
+        synchronized(_declaredMethods[1]) {
+            _declaredMethods[1].clear();
+        }
         _methodAccessCache.clear();
         _methodPermCache.clear();
+    }
+
+    /**
+     * Clears some additional caches used by OgnlRuntime.  The existing {@link OgnlRuntime#clearCache()}
+     * clears the standard reflection-related caches, but some applications may have need to clear
+     * the additional caches as well.
+     *
+     * Clearing the additional caches may have greater impact than the {@link OgnlRuntime#clearCache()}
+     * method so it should only be used when the normal cache clear is insufficient.
+     *
+     * <p>
+     * <strong>Warning:</strong> Calling this method too often can be a huge performance
+     * drain on your expressions - use with care.
+     * </p>
+     *
+     * @since 3.1.25
+     */
+    public static void clearAdditionalCache()
+    {
+        cacheSetMethod.clear();
+        cacheGetMethod.clear();
+        synchronized(_genericMethodParameterTypesCache) {
+          _genericMethodParameterTypesCache.clear();
+        }
     }
 
     /**
@@ -1429,8 +1473,16 @@ public class OgnlRuntime {
                             }
                         }
                         if (scoreCurr == scoreOther) {
-                            if (failure == null)
-                                System.err.println("Two methods with same score("+score+"): \""+mm.mMethod+"\" and \""+m+"\" please report!");
+                            if (failure == null) {
+                                boolean currentIsAbstract = Modifier.isAbstract(mm.mMethod.getModifiers());
+                                boolean otherIsAbstract = Modifier.isAbstract(m.getModifiers());
+                                if (! (currentIsAbstract ^ otherIsAbstract) ) {
+                                    // Only report as an error when the score is equal and BOTH methods are abstract or BOTH are concrete.
+                                    // If one is abstract and the other concrete then either choice should work for OGNL,
+                                    // so we just keep the current choice and continue (without error output).
+                                    System.err.println("Two methods with same score("+score+"): \""+mm.mMethod+"\" and \""+m+"\" please report!");
+                                }
+                            }
                         } else if (scoreCurr > scoreOther) {
                             // other wins...
                             mm = new MatchingMethod(m, score, report, mParameterTypes);
@@ -3357,6 +3409,15 @@ public class OgnlRuntime {
                 return false;
 
             return methodsByPropertyName.containsKey(propertyName);
+        }
+
+        /**
+         * Allow clearing for the underlying cache of the ClassPropertyMethodCache.
+         *
+         * @since 3.1.25
+         */
+        void clear() {
+            this.cache.clear();
         }
 
     }

--- a/src/test/java/ognl/TestOgnlRuntime.java
+++ b/src/test/java/ognl/TestOgnlRuntime.java
@@ -360,7 +360,7 @@ public class TestOgnlRuntime extends TestCase {
      * @throws Exception
      */
     public void testAbstractConcreteMethodScoringNoSysErr() throws Exception {
-        OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null);
+        OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null, new DefaultMemberAccess(false));
         ObjectMethodAccessor methodAccessor = new ObjectMethodAccessor();
         ConcreteTestClass concreteTestClass = new ConcreteTestClass();
         Object result = methodAccessor.callMethod(context, concreteTestClass, "testMethod", new Object[]{"Test", 1});


### PR DESCRIPTION
Forward-port PR#77 from 3.1.x to 3.2.x (cherry-pick).
Cache clearing enhancement (clear additional cache, synchronization fix) #70

The cherry-pick was clean, but one line in the unit test had to be changed (use of deprecated method in the test caused a failure, but was simple to correct).