### PR TITLE
Forward-port PR#69, PR#74 and PR#75 together from 3.1.x to 3.2.x (cherry-pick)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <build>
         <plugins>
             <plugin>
+                <!-- Source/target levels are at 1.7 (Travis CI now rejects 1.5) -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>

--- a/src/main/java/ognl/AccessibleObjectHandler.java
+++ b/src/main/java/ognl/AccessibleObjectHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * and/or LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.  The ASF licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ognl;
+
+import java.lang.reflect.AccessibleObject;
+
+/**
+ * This interface provides a mechanism for indirect reflection access processing
+ *   of AccessibleObject instances by OGNL.  It can be used to provide different
+ *   behaviour as JDK reflection mechanisms evolve.
+ *
+ * @since 3.1.24
+ */
+public abstract interface AccessibleObjectHandler
+{
+    /**
+     * Provides an appropriate implementation to change the accessibility of accessibleObject.
+     *
+     * @param accessibleObject
+     * @param flag
+     */
+    void setAccessible(AccessibleObject accessibleObject, boolean flag);
+}

--- a/src/main/java/ognl/AccessibleObjectHandlerJDK9Plus.java
+++ b/src/main/java/ognl/AccessibleObjectHandlerJDK9Plus.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * and/or LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.  The ASF licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ognl;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Utilizes a JDK 9 and later mechanism for changing the accessibility level of a given
+ *   AccessibleObject.
+ *
+ * If the JDK 9+ mechanism fails, this class will fall back to a standard pre-JDK 9 reflection mechanism.
+ *   Note:  That may cause "WARNING: Illegal reflective access" output to be generated to stdout/stderr.
+ *
+ * For reference, this class draws on information from the following locations:
+ *   - Post about Illegal Reflective Access <a href="https://stackoverflow.com/questions/50251798/what-is-an-illegal-reflective-access">what is an illegal reflective access</a>
+ *   - Blog on Unsafe <a href="http://mishadoff.com/blog/java-magic-part-4-sun-dot-misc-dot-unsafe/">Java Magic. Part 4: sun.misc.Unsafe</a>
+ *   - Blog on Unsafe <a href="https://www.baeldung.com/java-unsafe">Guide to sun.misc.Unsafe</a>
+ *   - JEP about access to Unsafe being retained in JDK 9 <a href="https://openjdk.java.net/jeps/260">JEP 260: Encapsulate Most Internal APIs</a>
+ *
+ * In addition to the above, inspiration was drawn from Gson: <a href="https://github.com/google/gson/pull/1218">PR 1218</a>,
+ *   <a href="https://github.com/google/gson/pull/1306">PR 1306</a>.
+ *
+ * Appreciation and credit to the authors, contributors and commenters for the information contained in the preceding links.
+ *
+ * @since 3.1.24
+ */
+class AccessibleObjectHandlerJDK9Plus implements AccessibleObjectHandler
+{
+    private static final Class _clazzUnsafe = instantiateClazzUnsafe();
+    private static final Object _unsafeInstance = instantiateUnsafeInstance(_clazzUnsafe);
+    private static final Method _unsafeObjectFieldOffsetMethod = instantiateUnsafeObjectFieldOffsetMethod(_clazzUnsafe);
+    private static final Method _unsafePutBooleanMethod = instantiateUnsafePutBooleanMethod(_clazzUnsafe);
+    private static final Field _accessibleObjectOverrideField = instantiateAccessibleObjectOverrideField();
+    private static final long _accessibleObjectOverrideFieldOffset = determineAccessibleObjectOverrideFieldOffset();
+
+    /**
+     * Private constructor
+     */
+    private AccessibleObjectHandlerJDK9Plus() {}
+
+    /**
+     * Package-accessible method to determine if a given class is Unsafe or a descendant
+     *   of Unsafe.
+     *
+     * @param clazz
+     * @return true if parameter is Unsafe or a descendant, false otherwise
+     */
+    static boolean unsafeOrDescendant(final Class clazz) {
+        return (_clazzUnsafe != null ? _clazzUnsafe.isAssignableFrom(clazz) : false);
+    }
+
+    /**
+     * Instantiate an instance of the Unsafe class.
+     *
+     * @return class if available, null otherwise
+     */
+    private static Class instantiateClazzUnsafe() {
+        Class clazz;
+
+        try {
+            clazz = Class.forName("sun.misc.Unsafe");
+        } catch (Throwable t) {
+            clazz = null;
+        }
+
+        return clazz;
+    }
+
+    /**
+     * Instantiate an instance of Unsafe object.
+     *
+     * @param clazz (expected to be an Unsafe instance)
+     * @return instance if available, null otherwise
+     */
+    private static Object instantiateUnsafeInstance(Class clazz) {
+        Object unsafe;
+
+        if (clazz != null) {
+            Field field = null;
+            try {
+                field = clazz.getDeclaredField("theUnsafe");
+                field.setAccessible(true);
+                unsafe = field.get(null);
+            } catch (Throwable t) {
+                unsafe = null;
+            } finally {
+                if (field != null) {
+                    try {
+                        field.setAccessible(false);
+                    } catch (Throwable t) {
+                        // Don't care
+                    }
+                }
+            }
+        } else {
+            unsafe = null;
+        }
+
+        return unsafe;
+    }
+
+    /**
+     * Instantiate an Unsafe.objectFieldOffset() method instance.
+     *
+     * @param clazz (expected to be an Unsafe instance)
+     * @return method if available, null otherwise
+     */
+    private static Method instantiateUnsafeObjectFieldOffsetMethod(Class clazz) {
+        Method method;
+
+        if (clazz != null) {
+            try {
+                method = clazz.getMethod("objectFieldOffset", Field.class);
+            } catch (Throwable t) {
+                method = null;
+            }
+        } else {
+            method = null;
+        }
+
+        return method;
+    }
+
+    /**
+     * Instantiate an Unsafe.putBoolean() method instance.
+     *
+     * @param clazz (expected to be an Unsafe instance)
+     * @return method if available, null otherwise
+     */
+    private static Method instantiateUnsafePutBooleanMethod(Class clazz) {
+        Method method;
+
+        if (clazz != null) {
+            try {
+                method = clazz.getMethod("putBoolean", Object.class, long.class, boolean.class);
+            } catch (Throwable t) {
+                method = null;
+            }
+        } else {
+            method = null;
+        }
+
+        return method;
+    }
+
+    /**
+     * Instantiate an AccessibleObject override field instance.
+     *
+     * @return field if available, null otherwise
+     */
+    private static Field instantiateAccessibleObjectOverrideField() {
+        Field field;
+
+        try {
+            field = AccessibleObject.class.getDeclaredField("override");
+        } catch (Throwable t) {
+            field = null;
+        }
+
+        return field;
+    }
+
+    /**
+     * Attempt to determined the AccessibleObject override field offset.
+     *
+     * @return field offset if available, -1 otherwise
+     */
+    private static long determineAccessibleObjectOverrideFieldOffset() {
+        long offset = -1;
+
+        if (_accessibleObjectOverrideField != null && _unsafeObjectFieldOffsetMethod != null && _unsafeInstance != null) {
+            try {
+                offset = (Long) _unsafeObjectFieldOffsetMethod.invoke(_unsafeInstance, _accessibleObjectOverrideField);
+            } catch (Throwable t) {
+                // Don't care (offset already -1)
+            }
+        }
+
+        return offset;
+    }
+
+    /**
+     * Package-level generator of an AccessibleObjectHandlerJDK9Plus instance.
+     *
+     * Not intended for use outside of the package.
+     *
+     * Note: An AccessibleObjectHandlerJDK9Plus will only be created if running on a
+     *   JDK9+ and the environment flag is set.  Otherwise this method will return
+     *   an AccessibleHandlerPreJDK9 instance instead,
+     *
+     * @return an AccessibleObjectHandler instance
+     *
+     * @since 3.1.24
+     */
+    static AccessibleObjectHandler createHandler() {
+        if (OgnlRuntime.usingJDK9PlusAccessHandler()){
+            return new AccessibleObjectHandlerJDK9Plus();
+        } else {
+            return AccessibleObjectHandlerPreJDK9.createHandler();
+        }
+    }
+
+    /**
+     * Utilize accessibility modification mechanism for JDK 9 (Java Major Version 9) and later.
+     *   Should that mechanism fail, attempt a standard pre-JDK9 accessibility modification.
+     *
+     * @param accessibleObject
+     * @param flag
+     */
+    public void setAccessible(AccessibleObject accessibleObject, boolean flag) {
+        boolean operationComplete = false;
+
+        if (_unsafeInstance != null && _unsafePutBooleanMethod != null && _accessibleObjectOverrideFieldOffset != -1) {
+            try {
+                _unsafePutBooleanMethod.invoke(_unsafeInstance, accessibleObject, _accessibleObjectOverrideFieldOffset, flag);
+                operationComplete = true;
+            } catch (Throwable t) {
+                // Don't care (operationComplete already false)
+            }
+        }
+        if (!operationComplete) {
+            // Fallback to standard reflection if Unsafe processing fails
+            accessibleObject.setAccessible(flag);
+        }
+    }
+
+}

--- a/src/main/java/ognl/AccessibleObjectHandlerPreJDK9.java
+++ b/src/main/java/ognl/AccessibleObjectHandlerPreJDK9.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * and/or LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.  The ASF licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ognl;
+
+import java.lang.reflect.AccessibleObject;
+
+/**
+ * Utilizes a standard pre-JDK 9 reflection mechanism for changing the accessibility level of
+ *   a given AccessibleObject.
+ *
+ * @since 3.1.24
+ */
+class AccessibleObjectHandlerPreJDK9 implements AccessibleObjectHandler
+{
+
+    /**
+     * Private constructor
+     */
+    private AccessibleObjectHandlerPreJDK9() {}
+
+    /**
+     * Package-level generator of an AccessibleObjectHandlerJDK9Plus instance.
+     *
+     * Not intended for use outside of the package.
+     *
+     * @return an AccessibleObjectHandler instance
+     *
+     * @since 3.1.24
+     */
+    static AccessibleObjectHandler createHandler() {
+        return new AccessibleObjectHandlerPreJDK9();
+    }
+
+    /**
+     * Utilize accessibility modification mechanism for JDK 8 (Java Major Version 8) and earlier.
+     *   It is also the default modification mechanism for JDK 9+.
+     *
+     * @param accessibleObject
+     * @param flag
+     */
+    public void setAccessible(AccessibleObject accessibleObject, boolean flag) {
+        accessibleObject.setAccessible(flag);
+    }
+
+}

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -34,12 +34,14 @@ import ognl.enhance.ExpressionCompiler;
 import ognl.enhance.OgnlExpressionCompiler;
 import ognl.internal.ClassCache;
 import ognl.internal.ClassCacheImpl;
+import ognl.security.OgnlSecurityManagerFactory;
+import ognl.security.UserMethod;
 
 import java.beans.*;
 import java.lang.reflect.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.security.Permission;
+import java.security.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -923,19 +925,91 @@ public class OgnlRuntime {
         {
             synchronized(method)
             {
+                if (checkPermission)
+                {
+                    try
+                    {
+                        _securityManager.checkPermission(getPermission(method));
+                    } catch (SecurityException ex) {
+                        throw new IllegalAccessException("Method [" + method + "] cannot be accessed.");
+                    }
+                }
+
                 ((AccessibleObject) method).setAccessible(true);
                 try {
-                    result = method.invoke(target, argsArray);
+                    result = invokeMethodInsideSandbox(target, method, argsArray);
                 } finally {
                     ((AccessibleObject) method).setAccessible(false);
                 }
             }
         } else
         {
-            result = method.invoke(target, argsArray);
+            if (checkPermission)
+            {
+                try
+                {
+                    _securityManager.checkPermission(getPermission(method));
+                } catch (SecurityException ex) {
+                    throw new IllegalAccessException("Method [" + method + "] cannot be accessed.");
+                }
+            }
+
+            result = invokeMethodInsideSandbox(target, method, argsArray);
         }
 
         return result;
+    }
+
+    private static Object invokeMethodInsideSandbox(Object target, Method method, Object[] argsArray)
+            throws InvocationTargetException, IllegalAccessException {
+
+        try {
+            if (System.getProperty("ognl.security.manager") == null) {
+                return method.invoke(target, argsArray);
+            }
+        } catch (SecurityException ignored) {
+            // already enabled or user has applied a policy that doesn't allow read property so we have to honor user's sandbox
+        }
+
+        if (ClassLoader.class.isAssignableFrom(method.getDeclaringClass())) {
+            // to support OgnlSecurityManager.isAccessDenied
+            throw new IllegalAccessException("OGNL direct access to class loader denied!");
+        }
+
+        // creating object before entering sandbox to load classes out of the sandbox
+        UserMethod userMethod = new UserMethod(target, method, argsArray);
+        Permissions p = new Permissions(); // not any permission
+        ProtectionDomain pd = new ProtectionDomain(null, p);
+        AccessControlContext acc = new AccessControlContext(new ProtectionDomain[]{pd});
+
+        Object ognlSecurityManager = OgnlSecurityManagerFactory.getOgnlSecurityManager();
+
+        Long token;
+        try {
+            token = (Long) ognlSecurityManager.getClass().getMethod("enter").invoke(ognlSecurityManager);
+        } catch (NoSuchMethodException e) {
+            throw new InvocationTargetException(e);
+        }
+        if (token == null) {
+            // user has applied a policy that doesn't allow setSecurityManager so we have to honor user's sandbox
+            return method.invoke(target, argsArray);
+        }
+
+        // execute user method body with all permissions denied
+        try {
+            return AccessController.doPrivileged(userMethod, acc);
+        } catch (PrivilegedActionException e) {
+            if (e.getException() instanceof InvocationTargetException) {
+                throw (InvocationTargetException) e.getException();
+            }
+            throw new InvocationTargetException(e);
+        } finally {
+            try {
+                ognlSecurityManager.getClass().getMethod("leave", long.class).invoke(ognlSecurityManager, token);
+            } catch (NoSuchMethodException e) {
+                throw new InvocationTargetException(e);
+            }
+        }
     }
 
     /**

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -124,6 +124,193 @@ public class OgnlRuntime {
     private static boolean _jdk15 = false;
     private static boolean _jdkChecked = false;
 
+    /**
+     * Control usage of JDK9+ access handler using the JVM option:
+     *   -Dognl.UseJDK9PlusAccessHandler=true
+     *   -Dognl.UseJDK9PlusAccessHandler=false
+     *
+     * Note: Set to "true" to allow the new JDK9 and later behaviour, <b>provided a newer JDK9+
+     *   is detected</b>.  By default the standard pre-JDK9 AccessHandler will be used even when
+     *   running on JDK9+, so users must "opt-in" in order to enable the alternate JDK9+ AccessHandler.
+     *   Using the JDK9PlusAccessHandler <b>may</b> avoid / mask JDK9+ warnings of the form:
+     *     "WARNING: Illegal reflective access by ognl.OgnlRuntime"
+     *   or provide an alternative  when running in environments set with "--illegal-access=deny".
+     *
+     * Note:  The default behaviour is to use the standard pre-JDK9 access handler.
+     *   Using the "false" value has the same effect as omitting the option completely.
+     *
+     * Warning: Users are <b>strongly advised</b> to review their code and confirm they really
+     *   need the AccessHandler modifying access levels, looking at alternatives to avoid that need.
+     */
+    static final String USE_JDK9PLUS_ACESS_HANDLER = "ognl.UseJDK9PlusAccessHandler";
+
+    /**
+     * Control usage of "stricter" invocation processing by invokeMethod() using the JVM options:
+     *    -Dognl.UseStricterInvocation=true
+     *    -Dognl.UseStricterInvocation=false
+     *
+     * Note: Using the "true" value has the same effect as omitting the option completely.
+     *   The default behaviour is to use the "stricter" invocation processing.
+     *   Using the "false" value reverts to the older "less strict" invocation processing
+     *   (in the event the "stricter" processing causes issues for existing applications).
+     */
+    static final String USE_STRICTER_INVOCATION = "ognl.UseStricterInvocation";
+
+    /**
+     * Hold environment flag state associated with USE_JDK9PLUS_ACESS_HANDLER.
+     *   Default: false (if not set)
+     */
+    private static final boolean _useJDK9PlusAccessHandler;
+    static {
+        boolean initialFlagState = false;
+        try {
+            final String propertyString = System.getProperty(USE_JDK9PLUS_ACESS_HANDLER);
+            if (propertyString != null && propertyString.length() > 0) {
+                initialFlagState = Boolean.parseBoolean(propertyString);
+            }
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        _useJDK9PlusAccessHandler = initialFlagState;
+    }
+
+    /**
+     * Hold environment flag state associated with USE_STRICTER_INVOCATION.
+     *   Default: true (if not set)
+     */
+    private static final boolean _useStricterInvocation;
+    static {
+        boolean initialFlagState = true;
+        try {
+            final String propertyString = System.getProperty(USE_STRICTER_INVOCATION);
+            if (propertyString != null && propertyString.length() > 0) {
+                initialFlagState = Boolean.parseBoolean(propertyString);
+            }
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        _useStricterInvocation = initialFlagState;
+    }
+
+    /*
+     * Attempt to detect the system-reported Major Java Version (e.g. 5, 7, 11).
+     */
+    private static final int _majorJavaVersion = detectMajorJavaVersion();
+    private static final boolean _jdk9Plus = _majorJavaVersion >= 9;
+
+    /*
+     * Assign an accessibility modification mechanism, based on Major Java Version and Java option flag
+     *   flag {@link OgnlRuntime#USE_JDK9PLUS_ACESS_HANDLER}.
+     *
+     * Note: Will use the standard Pre-JDK9 accessibility modification mechanism unless OGNL is running
+     *   on JDK9+ and the Java option flag has also been set true.
+     */
+    private static final AccessibleObjectHandler _accessibleObjectHandler;
+    static {
+        _accessibleObjectHandler = usingJDK9PlusAccessHandler() ? AccessibleObjectHandlerJDK9Plus.createHandler() :
+            AccessibleObjectHandlerPreJDK9.createHandler();
+    }
+
+    /**
+     * Private references for use in blocking direct invocation by invokeMethod().
+     */
+    private static final Method SYS_CONSOLE_REF;
+    private static final Method SYS_EXIT_REF;
+    private static final Method AO_SETACCESSIBLE_REF;
+    private static final Method AO_SETACCESSIBLE_ARR_REF;
+
+    /**
+     * Initialize the Method references used for blocking usage within invokeMethod().
+     */
+    static {
+        Method setAccessibleMethod = null;
+        Method setAccessibleMethodArray = null;
+        Method systemExitMethod = null;
+        Method systemConsoleMethod = null;
+        try {
+            setAccessibleMethod = AccessibleObject.class.getMethod("setAccessible", new Class<?>[]{boolean.class});
+        } catch (NoSuchMethodException nsme) {
+            // Should not happen.  To debug, uncomment the next line.
+            //throw new IllegalStateException("OgnlRuntime initialization missing setAccessible method", nsme);
+        } catch (SecurityException se) {
+            // May be blocked by existing SecurityManager.  To debug, uncomment the next line.
+            //throw new SecurityException("OgnlRuntime initialization cannot access setAccessible method", se);
+        } finally {
+            AO_SETACCESSIBLE_REF = setAccessibleMethod;
+        }
+
+        try {
+            setAccessibleMethodArray = AccessibleObject.class.getMethod("setAccessible", new Class<?>[]{AccessibleObject[].class, boolean.class});
+        } catch (NoSuchMethodException nsme) {
+            // Should not happen.  To debug, uncomment the next line.
+            //throw new IllegalStateException("OgnlRuntime initialization missing setAccessible method", nsme);
+        } catch (SecurityException se) {
+            // May be blocked by existing SecurityManager.  To debug, uncomment the next line.
+            //throw new SecurityException("OgnlRuntime initialization cannot access setAccessible method", se);
+        } finally {
+            AO_SETACCESSIBLE_ARR_REF = setAccessibleMethodArray;
+        }
+
+        try {
+            systemExitMethod = System.class.getMethod("exit", new Class<?>[]{int.class});
+        } catch (NoSuchMethodException nsme) {
+            // Should not happen.  To debug, uncomment the next line.
+            //throw new IllegalStateException("OgnlRuntime initialization missing exit method", nsme);
+        } catch (SecurityException se) {
+            // May be blocked by existing SecurityManager.  To debug, uncomment the next line.
+            //throw new SecurityException("OgnlRuntime initialization cannot access exit method", se);
+        } finally {
+            SYS_EXIT_REF = systemExitMethod;
+        }
+
+        try {
+            systemConsoleMethod = System.class.getMethod("console", new Class<?>[]{});  // Not available in JDK 1.5 or earlier
+        } catch (NoSuchMethodException nsme) {
+            // May happen for JDK 1.5 and earlier.  To debug, uncomment the next line.
+            //throw new IllegalStateException("OgnlRuntime initialization missing console method", nsme);
+        } catch (SecurityException se) {
+            // May be blocked by existing SecurityManager.  To debug, uncomment the next line.
+            //throw new SecurityException("OgnlRuntime initialization cannot access console method", se);
+        } finally {
+            SYS_CONSOLE_REF = systemConsoleMethod;
+        }
+    }
+
+    /**
+     * Control usage of the OGNL Security Manager using the JVM option:
+     *   -Dognl.security.manager=true  (or any non-null value other than 'disable')
+     *
+     * Omit '-Dognl.security.manager=' or nullify the property to disable the feature.
+     *
+     * To forcibly disable the feature (only possible at OGNL Library initialization, use the option:
+     *   -Dognl.security.manager=forceDisableOnInit
+     *
+     * Users that have their own Security Manager implementations and no intention to use the OGNL SecurityManager
+     *   sandbox may choose to use the 'forceDisableOnInit' flag option for performance reasons (avoiding overhead
+     *   involving the system property security checks - when that feature will not be used).
+     */
+    static final String OGNL_SECURITY_MANAGER = "ognl.security.manager";
+    static final String OGNL_SM_FORCE_DISABLE_ON_INIT = "forceDisableOnInit";
+
+    /**
+     * Hold environment flag state associated with OGNL_SECURITY_MANAGER.  See
+     * {@link OgnlRuntime#OGNL_SECURITY_MANAGER} for more details.
+     *   Default: false (if not set).
+     */
+    private static final boolean _disableOgnlSecurityManagerOnInit;
+    static {
+        boolean initialFlagState = false;
+        try {
+            final String propertyString = System.getProperty(OGNL_SECURITY_MANAGER);
+            if (propertyString != null && propertyString.length() > 0) {
+                initialFlagState = OGNL_SM_FORCE_DISABLE_ON_INIT.equalsIgnoreCase(propertyString);
+            }
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        _disableOgnlSecurityManagerOnInit = initialFlagState;
+    }
+
     static final ClassCache _methodAccessors = new ClassCacheImpl();
     static final ClassCache _propertyAccessors = new ClassCacheImpl();
     static final ClassCache _elementsAccessors = new ClassCacheImpl();
@@ -443,6 +630,24 @@ public class OgnlRuntime {
         _jdkChecked = true;
 
         return _jdk15;
+    }
+
+    /**
+     * Get the Major Java Version detected by OGNL.
+     *
+     * @return Detected Major Java Version, or 5 (minimum supported version for OGNL) if unable to detect.
+     */
+    public static int getMajorJavaVersion() {
+        return _majorJavaVersion;
+    }
+
+    /**
+     * Check if the detected Major Java Version is 9 or higher (JDK 9+).
+     *
+     * @return Return true if the Detected Major Java version is 9 or higher, otherwise false.
+     */
+    public static boolean isJdk9Plus() {
+        return _jdk9Plus;
     }
 
     public static String getNumericValueGetter(Class type)
@@ -870,6 +1075,28 @@ public class OgnlRuntime {
         Boolean methodAccessCacheValue;
         Boolean methodPermCacheValue;
 
+        if (_useStricterInvocation) {
+            final Class methodDeclaringClass = method.getDeclaringClass();  // Note: synchronized(method) call below will already NPE, so no null check.
+            if ( (AO_SETACCESSIBLE_REF != null && AO_SETACCESSIBLE_REF.equals(method)) ||
+                 (AO_SETACCESSIBLE_ARR_REF != null && AO_SETACCESSIBLE_ARR_REF.equals(method)) ||
+                 (SYS_EXIT_REF != null && SYS_EXIT_REF.equals(method)) ||
+                 (SYS_CONSOLE_REF != null && SYS_CONSOLE_REF.equals(method)) ||
+                 AccessibleObjectHandler.class.isAssignableFrom(methodDeclaringClass) ||
+                 ClassResolver.class.isAssignableFrom(methodDeclaringClass) ||
+                 MethodAccessor.class.isAssignableFrom(methodDeclaringClass) ||
+                 MemberAccess.class.isAssignableFrom(methodDeclaringClass) ||
+                 OgnlContext.class.isAssignableFrom(methodDeclaringClass) ||
+                 Runtime.class.isAssignableFrom(methodDeclaringClass) ||
+                 ClassLoader.class.isAssignableFrom(methodDeclaringClass) ||
+                 ProcessBuilder.class.isAssignableFrom(methodDeclaringClass) ||
+                 AccessibleObjectHandlerJDK9Plus.unsafeOrDescendant(methodDeclaringClass) ) {
+                // Prevent calls to some specific methods, as well as all methods of certain classes/interfaces
+                //   for which no (apparent) legitimate use cases exist for their usage within OGNL invokeMethod().
+                throw new IllegalAccessException("Method [" + method + "] cannot be called from within OGNL invokeMethod() " +
+                        "under stricter invocation mode.");
+            }
+        }
+
         // only synchronize method invocation if it actually requires it
 
         synchronized(method) {
@@ -935,11 +1162,11 @@ public class OgnlRuntime {
                     }
                 }
 
-                ((AccessibleObject) method).setAccessible(true);
+                _accessibleObjectHandler.setAccessible(method, true);
                 try {
                     result = invokeMethodInsideSandbox(target, method, argsArray);
                 } finally {
-                    ((AccessibleObject) method).setAccessible(false);
+                    _accessibleObjectHandler.setAccessible(method, false);
                 }
             }
         } else
@@ -963,8 +1190,12 @@ public class OgnlRuntime {
     private static Object invokeMethodInsideSandbox(Object target, Method method, Object[] argsArray)
             throws InvocationTargetException, IllegalAccessException {
 
+        if (_disableOgnlSecurityManagerOnInit) {
+            return method.invoke(target, argsArray);  // Feature was disabled at OGNL initialization.
+        }
+
         try {
-            if (System.getProperty("ognl.security.manager") == null) {
+            if (System.getProperty(OGNL_SECURITY_MANAGER) == null) {
                 return method.invoke(target, argsArray);
             }
         } catch (SecurityException ignored) {
@@ -3505,5 +3736,135 @@ public class OgnlRuntime {
 
     }
 
+    /**
+     * Detect the (reported) Major Java version running OGNL.
+     *
+     * Should support naming conventions of pre-JDK9 and JDK9+.
+     * See <a href="https://openjdk.java.net/jeps/223">JEP 223: New Version-String Scheme</a> for details.
+     *
+     * @return Detected Major Java Version, or 5 (minimum supported version for OGNL) if unable to detect.
+     *
+     * @since 3.1.25
+     */
+    static int detectMajorJavaVersion() {
+        int majorVersion = -1;
+        try {
+            majorVersion = parseMajorJavaVersion(System.getProperty("java.version"));
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        if (majorVersion == -1) {
+            majorVersion = 5;  // Return minimum supported Java version for OGNL
+        }
+
+        return majorVersion;
+    }
+
+    /**
+     * Parse a Java version string to determine the Major Java version.
+     *
+     * Should support naming conventions of pre-JDK9 and JDK9+.
+     * See <a href="https://openjdk.java.net/jeps/223">JEP 223: New Version-String Scheme</a> for details.
+     *
+     * @return Detected Major Java Version, or 5 (minimum supported version for OGNL) if unable to detect.
+     *
+     * @since 3.1.25
+     */
+    static int parseMajorJavaVersion(String versionString) {
+        int majorVersion = -1;
+        try {
+            if (versionString != null && versionString.length() > 0) {
+                final String[] sections = versionString.split("[\\.\\-\\+]");
+                final int firstSection;
+                final int secondSection;
+                if (sections.length > 0) {  // Should not happen, guard anyway
+                    if (sections[0].length() > 0) {
+                        if (sections.length > 1  && sections[1].length() > 0) {
+                            firstSection = Integer.parseInt(sections[0]);
+                            if (sections[1].matches("\\d+")) {
+                                secondSection = Integer.parseInt(sections[1]);
+                            } else {
+                                secondSection = -1;
+                            }
+                        } else  {
+                            firstSection = Integer.parseInt(sections[0]);
+                            secondSection = -1;
+                        }
+                        if (firstSection == 1 && secondSection != -1) {
+                            majorVersion = secondSection;  // Pre-JDK 9 versioning
+                        } else {
+                            majorVersion = firstSection;   // JDK9+ versioning
+                        }
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            // Unavailable (NumberFormatException, etc.)
+        }
+        if (majorVersion == -1) {
+            majorVersion = 5;  // Return minimum supported Java version for OGNL
+        }
+
+        return majorVersion;
+    }
+
+    /**
+     * Returns the value of the flag indicating whether the JDK9+ access handler has been
+     *   been requested (it can then be used if the Major Java Version number is 9+).
+     *
+     * Note: Value is controlled by a Java option flag {@link OgnlRuntime#USE_JDK9PLUS_ACESS_HANDLER}.
+     *
+     * @return true if a request to use the JDK9+ access handler is requested, false otherwise (always use pre-JDK9 handler).
+     *
+     * @since 3.1.25
+     */
+    public static boolean getUseJDK9PlusAccessHandlerValue() {
+        return _useJDK9PlusAccessHandler;
+    }
+
+    /**
+     * Returns the value of the flag indicating whether "stricter" invocation is
+     *   in effect or not.
+     *
+     * Note: Value is controlled by a Java option flag {@link OgnlRuntime#USE_STRICTER_INVOCATION}.
+     *
+     * @return true if stricter invocation is in effect, false otherwise.
+     *
+     * @since 3.1.25
+     */
+    public static boolean getUseStricterInvocationValue() {
+        return _useStricterInvocation;
+    }
+
+    /**
+     * Returns the value of the flag indicating whether the OGNL SecurityManager was disabled
+     *   on initialization or not.
+     *
+     * Note: Value is controlled by a Java option flag {@link OgnlRuntime#OGNL_SECURITY_MANAGER} using
+     *       the value {@link OgnlRuntime#OGNL_SM_FORCE_DISABLE_ON_INIT}.
+     *
+     * @return true if OGNL SecurityManager was disabled on initialization, false otherwise.
+     *
+     * @since 3.1.25
+     *
+     * @return
+     */
+    public static boolean getDisableOgnlSecurityManagerOnInitValue() {
+        return _disableOgnlSecurityManagerOnInit;
+    }
+
+    /**
+     * Returns an indication as to whether the current state indicates the
+     *   JDK9+ (9 and later) access handler is being used / should be used.  This
+     *   is based on a combination of the detected Major Java Version and the
+     *   Java option flag {@link OgnlRuntime#USE_JDK9PLUS_ACESS_HANDLER}.
+     *
+     * @return true if the JDK9 and later access handler is being used / should be used, false otherwise.
+     *
+     * @since 3.1.25
+     */
+    public static boolean usingJDK9PlusAccessHandler() {
+        return (_jdk9Plus && _useJDK9PlusAccessHandler);
+    }
 
 }

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -311,6 +311,36 @@ public class OgnlRuntime {
         _disableOgnlSecurityManagerOnInit = initialFlagState;
     }
 
+    /**
+     * Allow users to revert to the old "first match" lookup for getters/setters by OGNL using the JVM options:
+     *    -Dognl.UseFirstMatchGetSetLookup=true
+     *    -Dognl.UseFirstMatchGetSetLookup=false
+     *
+     * Note: Using the "false" value has the same effect as omitting the option completely.
+     *   The default behaviour is to use the "best match" lookup for getters/setters.
+     *   Using the "true" value reverts to the older "first match" lookup for getters/setters
+     *   (in the event the "best match" processing causes issues for existing applications).
+     */
+    static final String USE_FIRSTMATCH_GETSET_LOOKUP = "ognl.UseFirstMatchGetSetLookup";
+
+    /**
+     * Hold environment flag state associated with USE_FIRSTMATCH_GETSET_LOOKUP.
+     *   Default: false (if not set)
+     */
+    private static final boolean _useFirstMatchGetSetLookup;
+    static {
+        boolean initialFlagState = false;
+        try {
+            final String propertyString = System.getProperty(USE_FIRSTMATCH_GETSET_LOOKUP);
+            if (propertyString != null && propertyString.length() > 0) {
+                initialFlagState = Boolean.parseBoolean(propertyString);
+            }
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        _useFirstMatchGetSetLookup = initialFlagState;
+    }
+
     static final ClassCache _methodAccessors = new ClassCacheImpl();
     static final ClassCache _propertyAccessors = new ClassCacheImpl();
     static final ClassCache _elementsAccessors = new ClassCacheImpl();
@@ -2183,11 +2213,36 @@ public class OgnlRuntime {
 
     /**
      * Backport of java.lang.reflect.Method#isDefault()
+     *
+     * JDK8+ supports Default Methods for interfaces.  Default Methods are defined as:
+     *   public, non-abstract and declared within an interface (must also be non-static).
+     *
+     * @param method The Method to check against the requirements for a Default Method.
+     *
+     * @return true If the Method qualifies as a Default Method, false otherwise.
      */
     private static boolean isDefaultMethod(Method method)
     {
         return ((method.getModifiers()
                 & (Modifier.ABSTRACT | Modifier.PUBLIC | Modifier.STATIC)) == Modifier.PUBLIC)
+                && method.getDeclaringClass().isInterface();
+    }
+
+    /**
+     * Determine if the provided Method is a non-Default public Interface method.
+     *
+     * Public non-Default Methods are defined as:
+     *   public, abstract, non-static and declared within an interface.
+     *
+     * @param method The Method to check against the requirements for a non-Default Method.
+     *
+     * @return true If method qualifies as a non-Default public Interface method, false otherwise.
+     *
+     * @since 3.1.25
+     */
+    private static boolean isNonDefaultPublicInterfaceMethod(Method method) {
+        return ((method.getModifiers()
+                & (Modifier.ABSTRACT | Modifier.PUBLIC | Modifier.STATIC)) == (Modifier.ABSTRACT | Modifier.PUBLIC))
                 && method.getDeclaringClass().isInterface();
     }
 
@@ -2543,7 +2598,7 @@ public class OgnlRuntime {
         final Method[] methods = c.getDeclaredMethods();
         for (int i = 0; i < methods.length; i++) {
             if (c.isInterface()) {
-                if (isDefaultMethod(methods[i])) {
+                if (isDefaultMethod(methods[i]) || isNonDefaultPublicInterfaceMethod(methods[i])) {
                     addIfAccessor(result, methods[i], baseName, findSets);
                 }
                 continue;
@@ -2616,6 +2671,26 @@ public class OgnlRuntime {
         return method;
     }
 
+    /**
+     * Returns a qualifying get (getter) method, if one is available for the given targetClass and propertyName.
+     *
+     * Note: From OGNL 3.1.25 onward, this method will attempt to find the first get getter method(s) that match:
+     *         1) First get (getter) method, whether public or not.
+     *         2) First public get (getter) method, provided the method's declaring class is also public.
+     *            This may be the same as 1), if 1) is also public and its declaring class is also public.
+     *         3) First public non-Default interface get (getter) method, provided the method's declaring class is also public.
+     *       The <b>order of preference (priority)<b> for the above matches will be <b>2</b> (1st public getter),
+     *       <b>3</b> (1st public non-Default interface getter), <b>1</b> (1st getter of any kind).
+     *   This updated methodology should help limit the need to modify method accessibility levels in some circumstances.
+     *
+     * @param context The current execution context.
+     * @param targetClass Class to search for a get method (getter).
+     * @param propertyName Name of the property for the get method (getter).
+     *
+     * @return
+     * @throws IntrospectionException
+     * @throws OgnlException
+     */
     private static Method _getGetMethod(OgnlContext context, Class targetClass, String propertyName)
             throws IntrospectionException, OgnlException
     {
@@ -2625,6 +2700,9 @@ public class OgnlRuntime {
 
         if (methods != null)
         {
+            Method firstGetter = null;
+            Method firstPublicGetter = null;
+            Method firstNonDefaultPublicInterfaceGetter = null;
             for (int i = 0, icount = methods.size(); i < icount; i++)
             {
                 Method m = (Method) methods.get(i);
@@ -2632,10 +2710,24 @@ public class OgnlRuntime {
 
                 if (mParameterTypes.length == 0)
                 {
-                    result = m;
-                    break;
+                    boolean declaringClassIsPublic = Modifier.isPublic(m.getDeclaringClass().getModifiers());
+                    if (firstGetter == null) {
+                        firstGetter = m;
+                        if (_useFirstMatchGetSetLookup) {
+                            break;  // Stop looking (emulate original logic, return 1st match)
+                        }
+                    }
+                    if (firstPublicGetter == null && Modifier.isPublic(m.getModifiers()) && declaringClassIsPublic) {
+                        firstPublicGetter = m;
+                        break;  // Stop looking (this is the best possible match)
+                    }
+                    if (firstNonDefaultPublicInterfaceGetter == null && isNonDefaultPublicInterfaceMethod(m) && declaringClassIsPublic) {
+                        firstNonDefaultPublicInterfaceGetter = m;
+                    }
                 }
             }
+            result = (firstPublicGetter != null) ? firstPublicGetter :
+                    (firstNonDefaultPublicInterfaceGetter != null) ? firstNonDefaultPublicInterfaceGetter : firstGetter;
         }
 
         return result;
@@ -2673,6 +2765,26 @@ public class OgnlRuntime {
         return method;
     }
 
+    /**
+     * Returns a qualifying set (setter) method, if one is available for the given targetClass and propertyName.
+     *
+     * Note: From OGNL 3.1.25 onward, this method will attempt to find the first set setter method(s) that match:
+     *         1) First set (setter) method, whether public or not.
+     *         2) First public set (setter) method, provided the method's declaring class is also public.
+     *            This may be the same as 1), if 1) is also public and its declaring class is also public.
+     *         3) First public non-Default interface set (setter) method, provided the method's declaring class is also public.
+     *       The <b>order of preference (priority)<b> for the above matches will be <b>2</b> (1st public setter),
+     *       <b>3</b> (1st public non-Default interface setter), <b>1</b> (1st setter of any kind).
+     *   This updated methodology should help limit the need to modify method accessibility levels in some circumstances.
+     *
+     * @param context The current execution context.
+     * @param targetClass Class to search for a set method (setter).
+     * @param propertyName Name of the property for the set method (setter).
+     *
+     * @return
+     * @throws IntrospectionException
+     * @throws OgnlException
+     */
     private static Method _getSetMethod(OgnlContext context, Class targetClass, String propertyName)
             throws IntrospectionException, OgnlException
     {
@@ -2682,16 +2794,34 @@ public class OgnlRuntime {
 
         if (methods != null)
         {
+            Method firstSetter = null;
+            Method firstPublicSetter = null;
+            Method firstNonDefaultPublicInterfaceSetter = null;
             for (int i = 0, icount = methods.size(); i < icount; i++)
             {
                 Method m = (Method) methods.get(i);
                 Class[] mParameterTypes = findParameterTypes(targetClass, m); //getParameterTypes(m);
 
                 if (mParameterTypes.length == 1) {
-                    result = m;
-                    break;
+                    boolean declaringClassIsPublic = Modifier.isPublic(m.getDeclaringClass().getModifiers());
+                    if (firstSetter == null) {
+                        firstSetter = m;
+                        if (_useFirstMatchGetSetLookup) {
+                            break;  // Stop looking (emulate original logic, return 1st match)
+                        }
+                    }
+                    if (firstPublicSetter == null && Modifier.isPublic(m.getModifiers()) && declaringClassIsPublic) {
+                        firstPublicSetter = m;
+                        break;  // Stop looking (this is the best possible match)
+                    }
+                    if (firstNonDefaultPublicInterfaceSetter == null && isNonDefaultPublicInterfaceMethod(m) && declaringClassIsPublic) {
+                        firstNonDefaultPublicInterfaceSetter = m;
+                    }
                 }
             }
+
+            result = (firstPublicSetter != null) ? firstPublicSetter :
+                    (firstNonDefaultPublicInterfaceSetter != null) ? firstNonDefaultPublicInterfaceSetter : firstSetter;
         }
 
         return result;
@@ -3865,6 +3995,20 @@ public class OgnlRuntime {
      */
     public static boolean usingJDK9PlusAccessHandler() {
         return (_jdk9Plus && _useJDK9PlusAccessHandler);
+    }
+
+    /**
+     * Returns the value of the flag indicating whether the old "first match" lookup for
+     *   getters/setters is in effect or not.
+     *
+     * Note: Value is controlled by a Java option flag {@link OgnlRuntime#USE_FIRSTMATCH_GETSET_LOOKUP}.
+     *
+     * @return true if the old "first match" lookup is in effect, false otherwise.
+     *
+     * @since 3.1.25
+     */
+    public static boolean getUseFirstMatchGetSetLookupValue() {
+        return _useFirstMatchGetSetLookup;
     }
 
 }

--- a/src/main/java/ognl/security/OgnlSecurityManager.java
+++ b/src/main/java/ognl/security/OgnlSecurityManager.java
@@ -1,0 +1,122 @@
+package ognl.security;
+
+import java.io.FilePermission;
+import java.security.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Wraps current security manager with JDK security manager if is inside OgnlRuntime user's methods body execution.
+ *
+ * Add the `-Dognl.security.manager` to JVM options to enable.
+ *
+ * <p> Note: Due to potential performance and concurrency issues, try this only if you afraid your app can have an
+ * unknown "expression injection" flaw or you afraid you cannot prevent those in your app's internal sandbox
+ * comprehensively e.g. you cannot discover and maintain all attack vectors over time because of many dependencies
+ * and also their change over time.</p>
+ *
+ * <p> This tries to provide an option to you to enable a security manager that disables any sensitive action e.g.
+ * exec and exit even if attacker had a successful "expression injection" in any unknown way into your app. However,
+ * also honors previous security manager and policies if any set, as parent, and rolls back to them after method
+ * execution finished.</p>
+ *
+ * @author Yasser Zamani
+ * @since 3.1.24
+ */
+public class OgnlSecurityManager extends SecurityManager {
+    private static final String OGNL_SANDBOX_CLASS_NAME = "ognl.security.UserMethod";
+    private static final Class<?> CLASS_LOADER_CLASS = ClassLoader.class;
+    private static final Class<?> FILE_PERMISSION_CLASS = FilePermission.class;
+
+    private SecurityManager parentSecurityManager;
+    private List<Long> residents = new ArrayList<Long>();
+    private SecureRandom rnd = new SecureRandom();
+
+    public OgnlSecurityManager(SecurityManager parentSecurityManager) {
+        this.parentSecurityManager = parentSecurityManager;
+    }
+
+    private boolean isAccessDenied(Permission perm) {
+        Class[] classContext = getClassContext();
+        Boolean isInsideClassLoader = null;
+        for (Class c : classContext) {
+            if (isInsideClassLoader == null && CLASS_LOADER_CLASS.isAssignableFrom(c)) {
+                if (FILE_PERMISSION_CLASS.equals(perm.getClass()) && "read".equals(perm.getActions())) {
+                    // TODO: might be risky but we have to - fix it if any POC discovered
+                    // relax a bit with containers class loaders lazy class load
+                    return false;
+                } else {
+                    isInsideClassLoader = false;
+                }
+            }
+            if (OGNL_SANDBOX_CLASS_NAME.equals(c.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void checkPermission(Permission perm) {
+        if (parentSecurityManager != null) {
+            parentSecurityManager.checkPermission(perm);
+        }
+        if (isAccessDenied(perm)) {
+            super.checkPermission(perm);
+        }
+    }
+
+    @Override
+    public void checkPermission(Permission perm, Object context) {
+        if (parentSecurityManager != null) {
+            parentSecurityManager.checkPermission(perm, context);
+        }
+        if (isAccessDenied(perm)) {
+            super.checkPermission(perm, context);
+        }
+    }
+
+    public Long enter() {
+        synchronized (this) {
+            long token = rnd.nextLong();
+            if (residents.size() == 0) {
+                if (install()) {
+                    residents.add(token);
+                    return token;
+                } else {
+                    return null;
+                }
+            }
+            residents.add(token);
+            return token;
+        }
+    }
+
+    public void leave(long token) throws SecurityException {
+        synchronized (this) {
+            if (!residents.contains(token)) {
+                throw new SecurityException();
+            }
+            residents.remove(token);
+            if (residents.size() == 0) {
+                // no user so roll back to previous state to save performance
+                uninstall();
+            }
+        }
+    }
+
+    private boolean install() {
+        try {
+            System.setSecurityManager(this);
+        } catch (SecurityException ex) {
+            // user has applied a policy that doesn't allow setSecurityManager so we have to honor user's sandbox
+            return false;
+        }
+
+        return true;
+    }
+
+    private void uninstall() {
+        System.setSecurityManager(parentSecurityManager);
+    }
+}

--- a/src/main/java/ognl/security/OgnlSecurityManagerFactory.java
+++ b/src/main/java/ognl/security/OgnlSecurityManagerFactory.java
@@ -1,0 +1,71 @@
+package ognl.security;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.security.AllPermission;
+import java.security.PermissionCollection;
+import java.security.ProtectionDomain;
+import java.security.SecureClassLoader;
+
+/**
+ * Builds and provides a JVM wide singleton shared thread-safe with all permissions granted security manager for ognl
+ *
+ * @author Yasser Zamani
+ * @since 3.1.24
+ */
+public class OgnlSecurityManagerFactory extends SecureClassLoader {
+    private static Object ognlSecurityManager;
+
+    private Class<?> ognlSecurityManagerClass;
+
+    public static Object getOgnlSecurityManager() {
+        if (ognlSecurityManager == null) {
+            synchronized (SecurityManager.class) {
+                if (ognlSecurityManager == null) {
+                    SecurityManager sm = System.getSecurityManager();
+                    if (sm == null || !sm.getClass().getName().equals(OgnlSecurityManager.class.getName())) {
+                        try {
+                            ognlSecurityManager = new OgnlSecurityManagerFactory().build(sm);
+                        } catch (Exception ignored) {
+                            // not expected at all; anyway keep and return null as ognlSecurityManager
+                        }
+                    } else {
+                        ognlSecurityManager = sm;
+                    }
+                }
+            }
+        }
+        return ognlSecurityManager;
+    }
+
+    private OgnlSecurityManagerFactory() throws IOException {
+        super(OgnlSecurityManagerFactory.class.getClassLoader());
+
+        PermissionCollection pc = new AllPermission().newPermissionCollection();
+        pc.add(new AllPermission()); // grant all permissions to simulate JDK itself SecurityManager
+        ProtectionDomain pd = new ProtectionDomain(null, pc);
+
+        byte[] byteArray = toByteArray(getParent().getResourceAsStream(
+                OgnlSecurityManager.class.getName().replace('.', '/') + ".class"));
+        ognlSecurityManagerClass = defineClass(null, byteArray, 0, byteArray.length, pd);
+    }
+
+    private Object build(SecurityManager parentSecurityManager) throws NoSuchMethodException, IllegalAccessException,
+            InvocationTargetException, InstantiationException {
+
+        return ognlSecurityManagerClass.getConstructor(SecurityManager.class).newInstance(parentSecurityManager);
+    }
+
+    private static byte[] toByteArray(InputStream input) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        int n;
+        byte[] buffer = new byte[4096];
+        while(-1 != (n = input.read(buffer))) {
+            output.write(buffer, 0, n);
+        }
+
+        return output.toByteArray();
+    }
+}

--- a/src/main/java/ognl/security/UserMethod.java
+++ b/src/main/java/ognl/security/UserMethod.java
@@ -1,0 +1,26 @@
+package ognl.security;
+
+import java.lang.reflect.Method;
+import java.security.PrivilegedExceptionAction;
+
+/**
+ * A signature for {@link OgnlSecurityManager#isAccessDenied()}. Also executes user methods with not any permission.
+ *
+ * @author Yasser Zamani
+ * @since 3.1.24
+ */
+public class UserMethod implements PrivilegedExceptionAction<Object> {
+    private final Object target;
+    private final Method method;
+    private final Object[] argsArray;
+
+    public UserMethod(Object target, Method method, Object[] argsArray) {
+        this.target = target;
+        this.method = method;
+        this.argsArray = argsArray;
+    }
+
+    public Object run() throws Exception {
+        return method.invoke(target, argsArray);
+    }
+}

--- a/src/test/java/ognl/DefaultMemberAccess.java
+++ b/src/test/java/ognl/DefaultMemberAccess.java
@@ -47,6 +47,16 @@ import java.util.*;
  */
 public class DefaultMemberAccess implements MemberAccess
 {
+    /*
+     * Assign an accessibility modification mechanism, based on Major Java Version.
+     *   Note: Can be override using a Java option flag {@link OgnlRuntime#USE_PREJDK9_ACESS_HANDLER}.
+     */
+    private static final AccessibleObjectHandler _accessibleObjectHandler;
+    static {
+        _accessibleObjectHandler = OgnlRuntime.usingJDK9PlusAccessHandler() ? AccessibleObjectHandlerJDK9Plus.createHandler() :
+            AccessibleObjectHandlerPreJDK9.createHandler();
+    }
+
     public boolean      allowPrivateAccess = false;
     public boolean      allowProtectedAccess = false;
     public boolean      allowPackageProtectedAccess = false;
@@ -112,7 +122,7 @@ public class DefaultMemberAccess implements MemberAccess
 
             if (!accessible.isAccessible()) {
                 result = Boolean.FALSE;
-                accessible.setAccessible(true);
+                _accessibleObjectHandler.setAccessible(accessible, true);
             }
         }
         return result;
@@ -124,7 +134,7 @@ public class DefaultMemberAccess implements MemberAccess
             final AccessibleObject  accessible = (AccessibleObject) member;
             final boolean           stateboolean = ((Boolean) state).booleanValue();  // Using twice (avoid unboxing)
             if (!stateboolean) {
-                accessible.setAccessible(stateboolean);
+                _accessibleObjectHandler.setAccessible(accessible, stateboolean);
             } else {
                 throw new IllegalArgumentException("Improper restore state [" + stateboolean + "] for target [" + target +
                                                    "], member [" + member + "], propertyName [" + propertyName + "]");

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -471,4 +471,33 @@ public class OgnlRuntimeTest {
         }
     }
 
+    /**
+     * Test OgnlRuntime value for _useFirstMatchGetSetLookup based on the System property
+     *   represented by {@link OgnlRuntime#USE_FIRSTMATCH_GETSET_LOOKUP}.
+     */
+    @Test
+    public void testUseFirstMatchGetSetStateFlag() {
+        // Ensure no exceptions, basic ouput for test report and sanity check on flag state.
+        final boolean defaultValue = false;          // Expected non-configured default
+        boolean optionDefinedInEnvironment = false;  // Track if option defined in environment
+        boolean flagValueFromEnvironment = false;    // Value result from environment retrieval
+        try {
+            final String propertyString = System.getProperty(OgnlRuntime.USE_FIRSTMATCH_GETSET_LOOKUP);
+            if (propertyString != null && propertyString.length() > 0) {
+                optionDefinedInEnvironment = true;
+                flagValueFromEnvironment = Boolean.parseBoolean(propertyString);
+            }
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        if (optionDefinedInEnvironment) {
+            System.out.println("System property " + OgnlRuntime.USE_FIRSTMATCH_GETSET_LOOKUP + " value: " + flagValueFromEnvironment);
+        } else {
+            System.out.println("System property " + OgnlRuntime.USE_FIRSTMATCH_GETSET_LOOKUP + " not present.  Default value should be: " + defaultValue);
+        }
+        System.out.println("Current OGNL value for Use First Match Get/Set State Flag: " + OgnlRuntime.getUseFirstMatchGetSetLookupValue());
+        Assert.assertEquals("Mismatch between system property (or default) and OgnlRuntime _useFirstMatchGetSetLookup flag state ?",
+                optionDefinedInEnvironment ? flagValueFromEnvironment : defaultValue, OgnlRuntime.getUseFirstMatchGetSetLookupValue());
+    }
+
 }

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -316,4 +316,159 @@ public class OgnlRuntimeTest {
                     (cumulativelRunTestElapsedNanoTime / (1000 * 1000 * 1000)) / totalNumberOfRunTestRuns + " s)");
         }
     }
+
+    /**
+     * Test OgnlRuntime version parsing mechanism.
+     */
+    @Test
+    public void testMajorJavaVersionParse() {
+        // Pre-JDK 9 version strings.
+        Assert.assertEquals("JDK 5 version check failed ?", 5, OgnlRuntime.parseMajorJavaVersion("1.5"));
+        Assert.assertEquals("JDK 5 version check failed ?", 5, OgnlRuntime.parseMajorJavaVersion("1.5.0"));
+        Assert.assertEquals("JDK 5 version check failed ?", 5, OgnlRuntime.parseMajorJavaVersion("1.5.0_21-b11"));
+        Assert.assertEquals("JDK 6 version check failed ?", 6, OgnlRuntime.parseMajorJavaVersion("1.6"));
+        Assert.assertEquals("JDK 6 version check failed ?", 6, OgnlRuntime.parseMajorJavaVersion("1.6.0"));
+        Assert.assertEquals("JDK 6 version check failed ?", 6, OgnlRuntime.parseMajorJavaVersion("1.6.0_43-b19"));
+        Assert.assertEquals("JDK 7 version check failed ?", 7, OgnlRuntime.parseMajorJavaVersion("1.7"));
+        Assert.assertEquals("JDK 7 version check failed ?", 7, OgnlRuntime.parseMajorJavaVersion("1.7.0"));
+        Assert.assertEquals("JDK 7 version check failed ?", 7, OgnlRuntime.parseMajorJavaVersion("1.7.0_79-b15"));
+        Assert.assertEquals("JDK 8 version check failed ?", 8, OgnlRuntime.parseMajorJavaVersion("1.8"));
+        Assert.assertEquals("JDK 8 version check failed ?", 8, OgnlRuntime.parseMajorJavaVersion("1.8.0"));
+        Assert.assertEquals("JDK 8 version check failed ?", 8, OgnlRuntime.parseMajorJavaVersion("1.8.0_201-b20"));
+        Assert.assertEquals("JDK 8 version check failed ?", 8, OgnlRuntime.parseMajorJavaVersion("1.8.0-someopenjdkstyle"));
+        Assert.assertEquals("JDK 8 version check failed ?", 8, OgnlRuntime.parseMajorJavaVersion("1.8.0_201-someopenjdkstyle"));
+        // JDK 9 and later version strings.
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9"));
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9-ea+19"));
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9+100"));
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9-ea+19"));
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9.1.3+15"));
+        Assert.assertEquals("JDK 9 version check failed ?", 9, OgnlRuntime.parseMajorJavaVersion("9-someopenjdkstyle"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10-ea+11"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10+10"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10-ea+11"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10.1.3+15"));
+        Assert.assertEquals("JDK 10 version check failed ?", 10, OgnlRuntime.parseMajorJavaVersion("10-someopenjdkstyle"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11-ea+22"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11+33"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11-ea+19"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11.1.3+15"));
+        Assert.assertEquals("JDK 11 version check failed ?", 11, OgnlRuntime.parseMajorJavaVersion("11-someopenjdkstyle"));
+    }
+
+    /**
+     * Test OgnlRuntime Major Version Check mechanism.
+     */
+    @Test
+    public void testMajorJavaVersionCheck() {
+        // Ensure no exceptions, basic ouput for test report and sanity check on minimum version.
+        final int majorJavaVersion = OgnlRuntime.detectMajorJavaVersion();
+        System.out.println("Major Java Version detected: " + majorJavaVersion);
+        Assert.assertTrue("Major Java Version Check returned value (" + majorJavaVersion + ") less than minimum (5) ?", majorJavaVersion >= 5);
+    }
+
+    /**
+     * Test OgnlRuntime value for _useJDK9PlusAccessHandler based on the System property
+     *   represented by {@link OgnlRuntime#USE_JDK9PLUS_ACESS_HANDLER}.
+     */
+    @Test
+    public void testAccessHanderStateFlag() {
+        // Ensure no exceptions, basic ouput for test report and sanity check on flag state.
+        final boolean defaultValue = false;          // Expected non-configured default
+        boolean optionDefinedInEnvironment = false;  // Track if option defined in environment
+        boolean flagValueFromEnvironment = false;    // Value result from environment retrieval
+        try {
+            final String propertyString = System.getProperty(OgnlRuntime.USE_JDK9PLUS_ACESS_HANDLER);
+            if (propertyString != null && propertyString.length() > 0) {
+                optionDefinedInEnvironment = true;
+                flagValueFromEnvironment = Boolean.parseBoolean(propertyString);
+            }
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        if (optionDefinedInEnvironment) {
+            System.out.println("System property " + OgnlRuntime.USE_JDK9PLUS_ACESS_HANDLER + " value: " + flagValueFromEnvironment);
+        } else {
+            System.out.println("System property " + OgnlRuntime.USE_JDK9PLUS_ACESS_HANDLER + " not present.  Default value should be: " + defaultValue);
+        }
+        System.out.println("Current OGNL value for use JDK9+ Access Handler: " + OgnlRuntime.getUseJDK9PlusAccessHandlerValue());
+        Assert.assertEquals("Mismatch between system property (or default) and OgnlRuntime _usJDK9PlusAccessHandler flag state ?",
+                optionDefinedInEnvironment ? flagValueFromEnvironment : defaultValue, OgnlRuntime.getUseJDK9PlusAccessHandlerValue());
+    }
+
+    /**
+     * Test OgnlRuntime value for _useStricterInvocation based on the System properties
+     *   represented by {@link OgnlRuntime#USE_STRICTER_INVOCATION}.
+     */
+    @Test
+    public void testUseStricterInvocationStateFlag() {
+        // Ensure no exceptions, basic ouput for test report and sanity check on flag state.
+        final boolean defaultValue = true;           // Expected non-configured default
+        boolean optionDefinedInEnvironment = false;  // Track if option defined in environment
+        boolean flagValueFromEnvironment = true;     // Expected non-configured default
+        try {
+            final String propertyString = System.getProperty(OgnlRuntime.USE_STRICTER_INVOCATION);
+            if (propertyString != null && propertyString.length() > 0) {
+                optionDefinedInEnvironment = true;
+                flagValueFromEnvironment = Boolean.parseBoolean(propertyString);
+            }
+        } catch (Exception ex) {
+            // Unavailable (SecurityException, etc.)
+        }
+        if (optionDefinedInEnvironment) {
+            System.out.println("System property " + OgnlRuntime.USE_STRICTER_INVOCATION + " value: " + flagValueFromEnvironment);
+        } else {
+            System.out.println("System property " + OgnlRuntime.USE_STRICTER_INVOCATION + " not present.  Default value should be: " + defaultValue);
+        }
+        System.out.println("Current OGNL value for use stricter invocation: " + OgnlRuntime.getUseStricterInvocationValue());
+        Assert.assertEquals("Mismatch between system property (or default) and OgnlRuntime _useStricterInvocation flag state ?",
+                optionDefinedInEnvironment ? flagValueFromEnvironment : defaultValue, OgnlRuntime.getUseStricterInvocationValue());
+    }
+
+    /**
+     * Test OgnlRuntime stricter invocation mode.
+     */
+    @Test
+    public void testStricterInvocationMode() {
+        // Ensure no exceptions, basic ouput for test report and sanity check on flag state.
+        // Note: If stricter invocation mode is disabled (due to a system property being set for
+        //   the JVM running the test) this test will not fail, but just skip the test.
+        if ( OgnlRuntime.getUseStricterInvocationValue()) {
+            try {
+                final Class<?>[] singleClassArgument = new Class<?>[1];
+                singleClassArgument[0] = int.class;
+                final Method exitMethod = System.class.getMethod("exit", singleClassArgument);
+                try {
+                    OgnlRuntime.invokeMethod(System.class, exitMethod, new Object[] { -1 });
+                    Assert.fail("Somehow got past invocation of a restricted exit call (nonsensical result) ?");
+                } catch (IllegalAccessException iae) {
+                    // Expected failure (failed during invocation)
+                    System.out.println("Stricter invocation mode blocked restricted call (as expected).  Exception: " + iae);
+                } catch (SecurityException se) {
+                    // Possible exception if test is run with an active security manager)
+                    System.out.println("Stricter invocation mode blocked by security manager (may be valid).  Exception: " + se);
+                }
+
+                singleClassArgument[0] = String.class;
+                final Method execMethod = Runtime.class.getMethod("exec", singleClassArgument);
+                try {
+                    OgnlRuntime.invokeMethod(Runtime.getRuntime(), execMethod, new Object[] { "fakeCommand" });
+                    Assert.fail("Somehow got past invocation of a restricted exec call ?");
+                } catch (IllegalAccessException iae) {
+                    // Expected failure (failed during invocation)
+                    System.out.println("Stricter invocation mode blocked restricted call (as expected).  Exception: " + iae);
+                } catch (SecurityException se) {
+                    // Possible exception if test is run with an active security manager)
+                    System.out.println("Stricter invocation mode blocked by security manager (may be valid).  Exception: " + se);
+                }
+            } catch (Exception ex) {
+                Assert.fail("Unable to fully test stricter invocation mode.  Exception: " + ex);
+            }
+        } else {
+            System.out.println("Not testing stricter invocation mode (disabled via system property).");
+        }
+    }
+
 }

--- a/src/test/java/ognl/TestOgnlRuntime.java
+++ b/src/test/java/ognl/TestOgnlRuntime.java
@@ -188,6 +188,11 @@ public class TestOgnlRuntime extends TestCase {
 
     public void test_Call_Method_In_JDK_Sandbox()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Call_Method_In_JDK_Sandbox() -invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         OgnlContext context = (OgnlContext) this.context;
         GenericService service = new GenericServiceImpl();
 
@@ -196,7 +201,7 @@ public class TestOgnlRuntime extends TestCase {
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -210,19 +215,24 @@ public class TestOgnlRuntime extends TestCase {
             assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("execute"));
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }
 
     public void test_Call_Method_In_JDK_Sandbox_Thread_Safety()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Call_Method_In_JDK_Sandbox_Thread_Safety() invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         final OgnlContext context = (OgnlContext) this.context;
         final GenericService service = new GenericServiceImpl();
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -277,13 +287,18 @@ public class TestOgnlRuntime extends TestCase {
             assertEquals(0, numThreadsFailedTest.get());
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }
 
     public void test_Disable_JDK_Sandbox()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Disable_JDK_Sandbox() invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         OgnlContext context = (OgnlContext) this.context;
         GenericService service = new GenericServiceImpl();
 
@@ -291,7 +306,7 @@ public class TestOgnlRuntime extends TestCase {
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -302,17 +317,17 @@ public class TestOgnlRuntime extends TestCase {
             fail("JDK sandbox should block execution");
         } catch (Exception ex) {
             assertTrue(ex.getCause() instanceof InvocationTargetException);
-            assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("ognl.security.manager"));
+            assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains(OgnlRuntime.OGNL_SECURITY_MANAGER));
             assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("write"));
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
 
         temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -325,13 +340,13 @@ public class TestOgnlRuntime extends TestCase {
             assertTrue(ex.getCause().getMessage().contains("accessDeclaredMembers"));
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
 
         temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -346,13 +361,18 @@ public class TestOgnlRuntime extends TestCase {
             assertNull(((InvocationTargetException)ex.getCause()).getTargetException().getMessage());
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }
 
     public void test_Exit_JDK_Sandbox()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Exit_JDK_Sandbox() invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         OgnlContext context = (OgnlContext) this.context;
         GenericService service = new GenericServiceImpl();
 
@@ -360,7 +380,7 @@ public class TestOgnlRuntime extends TestCase {
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -374,13 +394,18 @@ public class TestOgnlRuntime extends TestCase {
             assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("exit"));
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }
 
     public void test_Call_Method_In_JDK_Sandbox_Privileged()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Call_Method_In_JDK_Sandbox_Privileged() invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         OgnlContext context = (OgnlContext) this.context;
         GenericService service = new GenericServiceImpl();
 
@@ -388,7 +413,7 @@ public class TestOgnlRuntime extends TestCase {
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -404,13 +429,13 @@ public class TestOgnlRuntime extends TestCase {
             assertTrue(ex.getCause().getMessage().contains("test.properties"));
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
 
         temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -422,13 +447,18 @@ public class TestOgnlRuntime extends TestCase {
             assertNotSame(-1, result);
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }
 
     public void test_Class_Loader_Direct_Access()
             throws Exception {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            System.out.println("OGNL SecurityManager sandbox disabled by JVM option.  Skipping test_Class_Loader_Direct_Access() invocation test.");
+            return;  // JVM option was set to disable sandbox, do not attempt invocation.
+        }
+
         OgnlContext context = (OgnlContext) this.context;
         ClassLoader classLoader = getClass().getClassLoader();
 
@@ -437,7 +467,7 @@ public class TestOgnlRuntime extends TestCase {
 
         boolean temporaryEnabled = false;
         try {
-            System.setProperty("ognl.security.manager", "");
+            System.setProperty(OgnlRuntime.OGNL_SECURITY_MANAGER, "");
             temporaryEnabled = true;
         } catch (Exception ignore) {
             // already enabled
@@ -448,10 +478,17 @@ public class TestOgnlRuntime extends TestCase {
             fail("JDK sandbox should block execution");
         } catch (Exception ex) {
             assertTrue(ex.getCause() instanceof IllegalAccessException);
-            assertEquals("OGNL direct access to class loader denied!", ex.getCause().getMessage());
+            if (OgnlRuntime.getUseStricterInvocationValue() == true) {
+                // Blocked by stricter invocation check first, if active.
+                assertTrue("Didn't find expected stricter invocation mode exception message ?",
+                        ex.getCause().getMessage().endsWith("] cannot be called from within OGNL invokeMethod() under stricter invocation mode."));
+            } else {
+                // Otherwise, blocked by OGNL SecurityManager sandbox.
+                assertEquals("OGNL direct access to class loader denied!", ex.getCause().getMessage());
+            }
         } finally {
             if (temporaryEnabled) {
-                System.clearProperty("ognl.security.manager");
+                System.clearProperty(OgnlRuntime.OGNL_SECURITY_MANAGER);
             }
         }
     }

--- a/src/test/java/ognl/TestOgnlRuntime.java
+++ b/src/test/java/ognl/TestOgnlRuntime.java
@@ -6,10 +6,16 @@ import org.ognl.test.objects.*;
 import java.beans.PropertyDescriptor;
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Tests various methods / functionality of {@link ognl.OgnlRuntime}.
@@ -178,6 +184,276 @@ public class TestOgnlRuntime extends TestCase {
         args[0] = argument;
 
         assertEquals("Halo 3", OgnlRuntime.callMethod(context, service, "getFullMessageFor", args));
+    }
+
+    public void test_Call_Method_In_JDK_Sandbox()
+            throws Exception {
+        OgnlContext context = (OgnlContext) this.context;
+        GenericService service = new GenericServiceImpl();
+
+        Object[] args = OgnlRuntime.getObjectArrayPool().create(1);
+        args[0] = 0;
+
+        boolean temporaryEnabled = false;
+        try {
+            System.setProperty("ognl.security.manager", "");
+            temporaryEnabled = true;
+        } catch (Exception ignore) {
+            // already enabled
+        }
+
+        try {
+            OgnlRuntime.callMethod(context, service, "exec", args);
+            fail("JDK sandbox should block execution");
+        } catch (Exception ex) {
+            assertTrue(ex.getCause() instanceof InvocationTargetException);
+            assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("execute"));
+        } finally {
+            if (temporaryEnabled) {
+                System.clearProperty("ognl.security.manager");
+            }
+        }
+    }
+
+    public void test_Call_Method_In_JDK_Sandbox_Thread_Safety()
+            throws Exception {
+        final OgnlContext context = (OgnlContext) this.context;
+        final GenericService service = new GenericServiceImpl();
+
+        boolean temporaryEnabled = false;
+        try {
+            System.setProperty("ognl.security.manager", "");
+            temporaryEnabled = true;
+        } catch (Exception ignore) {
+            // already enabled
+        }
+
+        try {
+            final int NUM_THREADS = 100;
+            final int MAX_WAIT_MS = 300;
+            ExecutorService exec = Executors.newFixedThreadPool(NUM_THREADS);
+            final CountDownLatch allThreadsWaitOnThis = new CountDownLatch(1);
+            final AtomicInteger numThreadsFailedTest = new AtomicInteger(0);
+            for (int i = 0; i < NUM_THREADS; ++i) {
+                exec.submit(new Runnable() {
+                    public void run() {
+                        try {
+                            allThreadsWaitOnThis.await();
+                        } catch (InterruptedException ignored) {
+                        }
+
+                        try {
+                            Thread.sleep((long) (Math.random() * MAX_WAIT_MS));
+                        } catch (InterruptedException ignored) {
+                        }
+
+                        Object[] args = OgnlRuntime.getObjectArrayPool().create(1);
+                        args[0] = Math.random() * MAX_WAIT_MS;
+
+                        try {
+                            OgnlRuntime.callMethod(context, service, "exec", args);
+                            numThreadsFailedTest.incrementAndGet();
+                        } catch (Exception ex) {
+                            if (!((ex.getCause() instanceof InvocationTargetException &&
+                                    ((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("execute"))
+                                    ||
+                                    (ex.getCause() instanceof SecurityException &&
+                                            ex.getCause().getMessage().contains("createClassLoader")))) {
+                                numThreadsFailedTest.incrementAndGet();
+                            }
+                        }
+                    }
+                });
+            }
+
+            // release all the threads
+            allThreadsWaitOnThis.countDown();
+
+            // wait for them all to finish
+            Thread.sleep(MAX_WAIT_MS * 3);
+            exec.shutdown();
+            exec.awaitTermination(MAX_WAIT_MS * 3, TimeUnit.MILLISECONDS);
+            assertTrue(exec.isTerminated());
+            assertEquals(0, numThreadsFailedTest.get());
+        } finally {
+            if (temporaryEnabled) {
+                System.clearProperty("ognl.security.manager");
+            }
+        }
+    }
+
+    public void test_Disable_JDK_Sandbox()
+            throws Exception {
+        OgnlContext context = (OgnlContext) this.context;
+        GenericService service = new GenericServiceImpl();
+
+        Object[] args = OgnlRuntime.getObjectArrayPool().create(0);
+
+        boolean temporaryEnabled = false;
+        try {
+            System.setProperty("ognl.security.manager", "");
+            temporaryEnabled = true;
+        } catch (Exception ignore) {
+            // already enabled
+        }
+
+        try {
+            OgnlRuntime.callMethod(context, service, "disableSandboxViaReflectionByProperty", args);
+            fail("JDK sandbox should block execution");
+        } catch (Exception ex) {
+            assertTrue(ex.getCause() instanceof InvocationTargetException);
+            assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("ognl.security.manager"));
+            assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("write"));
+        } finally {
+            if (temporaryEnabled) {
+                System.clearProperty("ognl.security.manager");
+            }
+        }
+
+        temporaryEnabled = false;
+        try {
+            System.setProperty("ognl.security.manager", "");
+            temporaryEnabled = true;
+        } catch (Exception ignore) {
+            // already enabled
+        }
+
+        try {
+            OgnlRuntime.callMethod(context, service, "disableSandboxViaReflectionByField", args);
+            fail("JDK sandbox should block execution");
+        } catch (Exception ex) {
+            assertTrue(ex.getCause().getMessage().contains("accessDeclaredMembers"));
+        } finally {
+            if (temporaryEnabled) {
+                System.clearProperty("ognl.security.manager");
+            }
+        }
+
+        temporaryEnabled = false;
+        try {
+            System.setProperty("ognl.security.manager", "");
+            temporaryEnabled = true;
+        } catch (Exception ignore) {
+            // already enabled
+        }
+
+        try {
+            OgnlRuntime.callMethod(context, service, "disableSandboxViaReflectionByMethod", args);
+            fail("JDK sandbox should block execution");
+        } catch (Exception ex) {
+            assertTrue(ex.getCause() instanceof InvocationTargetException);
+            assertTrue(((InvocationTargetException)ex.getCause()).getTargetException() instanceof SecurityException);
+            assertNull(((InvocationTargetException)ex.getCause()).getTargetException().getMessage());
+        } finally {
+            if (temporaryEnabled) {
+                System.clearProperty("ognl.security.manager");
+            }
+        }
+    }
+
+    public void test_Exit_JDK_Sandbox()
+            throws Exception {
+        OgnlContext context = (OgnlContext) this.context;
+        GenericService service = new GenericServiceImpl();
+
+        Object[] args = OgnlRuntime.getObjectArrayPool().create(0);
+
+        boolean temporaryEnabled = false;
+        try {
+            System.setProperty("ognl.security.manager", "");
+            temporaryEnabled = true;
+        } catch (Exception ignore) {
+            // already enabled
+        }
+
+        try {
+            OgnlRuntime.callMethod(context, service, "exit", args);
+            fail("JDK sandbox should block execution");
+        } catch (Exception ex) {
+            assertTrue(ex.getCause() instanceof InvocationTargetException);
+            assertTrue(((InvocationTargetException)ex.getCause()).getTargetException().getMessage().contains("exit"));
+        } finally {
+            if (temporaryEnabled) {
+                System.clearProperty("ognl.security.manager");
+            }
+        }
+    }
+
+    public void test_Call_Method_In_JDK_Sandbox_Privileged()
+            throws Exception {
+        OgnlContext context = (OgnlContext) this.context;
+        GenericService service = new GenericServiceImpl();
+
+        Object[] args = OgnlRuntime.getObjectArrayPool().create(0);
+
+        boolean temporaryEnabled = false;
+        try {
+            System.setProperty("ognl.security.manager", "");
+            temporaryEnabled = true;
+        } catch (Exception ignore) {
+            // already enabled
+        }
+
+        try {
+            OgnlRuntime.callMethod(context, service, "doNotPrivileged", args);
+            fail("JDK sandbox should block execution");
+        } catch (Exception ex) {
+            assertTrue(ex.getCause() instanceof SecurityException);
+            assertTrue(ex.getCause().getMessage().contains("FilePermission"));
+            assertTrue(ex.getCause().getMessage().contains("read"));
+            assertTrue(ex.getCause().getMessage().contains("test.properties"));
+        } finally {
+            if (temporaryEnabled) {
+                System.clearProperty("ognl.security.manager");
+            }
+        }
+
+        temporaryEnabled = false;
+        try {
+            System.setProperty("ognl.security.manager", "");
+            temporaryEnabled = true;
+        } catch (Exception ignore) {
+            // already enabled
+        }
+
+        try {
+            Object result = OgnlRuntime.callMethod(context, service, "doPrivileged", args);
+            assertNotNull(result);
+            assertNotSame(-1, result);
+        } finally {
+            if (temporaryEnabled) {
+                System.clearProperty("ognl.security.manager");
+            }
+        }
+    }
+
+    public void test_Class_Loader_Direct_Access()
+            throws Exception {
+        OgnlContext context = (OgnlContext) this.context;
+        ClassLoader classLoader = getClass().getClassLoader();
+
+        Object[] args = OgnlRuntime.getObjectArrayPool().create(1);
+        args[0] = "test.properties";
+
+        boolean temporaryEnabled = false;
+        try {
+            System.setProperty("ognl.security.manager", "");
+            temporaryEnabled = true;
+        } catch (Exception ignore) {
+            // already enabled
+        }
+
+        try {
+            OgnlRuntime.callMethod(context, classLoader, "getResourceAsStream", args);
+            fail("JDK sandbox should block execution");
+        } catch (Exception ex) {
+            assertTrue(ex.getCause() instanceof IllegalAccessException);
+            assertEquals("OGNL direct access to class loader denied!", ex.getCause().getMessage());
+        } finally {
+            if (temporaryEnabled) {
+                System.clearProperty("ognl.security.manager");
+            }
+        }
     }
 
     public void test_Class_Cache_Inspector()

--- a/src/test/java/org/ognl/test/objects/GenericService.java
+++ b/src/test/java/org/ognl/test/objects/GenericService.java
@@ -1,5 +1,8 @@
 package org.ognl.test.objects;
 
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
 /**
  *
  */
@@ -7,5 +10,19 @@ public interface GenericService {
 
     String getFullMessageFor(PersonGenericObject person, Object...arguments);
 
-    String getFullMessageFor(GameGenericObject game, Object...arguments);    
+    String getFullMessageFor(GameGenericObject game, Object...arguments);
+
+    void exec(long waitMilliseconds) throws InterruptedException, NoSuchMethodException, InvocationTargetException, IllegalAccessException;
+
+    void disableSandboxViaReflectionByProperty() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException;
+
+    void disableSandboxViaReflectionByField() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException, NoSuchFieldException;
+
+    void disableSandboxViaReflectionByMethod() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException;
+
+    void exit() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException;
+
+    int doNotPrivileged() throws IOException;
+
+    int doPrivileged() throws IOException;
 }

--- a/src/test/java/org/ognl/test/objects/GenericServiceImpl.java
+++ b/src/test/java/org/ognl/test/objects/GenericServiceImpl.java
@@ -9,6 +9,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.*;
 import java.util.List;
+import ognl.OgnlRuntime;
 
 /**
  *
@@ -28,6 +29,9 @@ public class GenericServiceImpl implements GenericService {
     }
 
     public void exec(long sleepMilliseconds) throws InterruptedException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         Thread.sleep(sleepMilliseconds);
         Object runtime = Runtime.class.getMethod("getRuntime").invoke(null);
         Object process = Runtime.class.getMethod("exec", String.class).invoke(runtime, "time");
@@ -35,11 +39,17 @@ public class GenericServiceImpl implements GenericService {
     }
 
     public void disableSandboxViaReflectionByProperty() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         Method clearPropertyMethod = System.class.getMethod("clearProperty", String.class);
         clearPropertyMethod.invoke(null, "ognl.security.manager");
     }
 
     public void disableSandboxViaReflectionByField() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException, NoSuchFieldException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         Method getOgnlSecurityManagerMethod = OgnlSecurityManagerFactory.class.getMethod("getOgnlSecurityManager");
         Object ognlSecurityManager = getOgnlSecurityManagerMethod.invoke(null);
         Field residentsField = ognlSecurityManager.getClass().getDeclaredField("residents");
@@ -53,6 +63,9 @@ public class GenericServiceImpl implements GenericService {
     }
 
     public void disableSandboxViaReflectionByMethod() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         Method getOgnlSecurityManagerMethod = OgnlSecurityManagerFactory.class.getMethod("getOgnlSecurityManager");
         Object ognlSecurityManager = getOgnlSecurityManagerMethod.invoke(null);
         SecureRandom rnd = new SecureRandom();
@@ -60,10 +73,16 @@ public class GenericServiceImpl implements GenericService {
     }
 
     public void exit() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         System.class.getMethod("exit", int.class).invoke(null, 0);
     }
 
     public int doNotPrivileged() throws IOException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         InputStream is = getClass().getClassLoader().getResource("test.properties").openStream();
         int result = is.read();
         is.close();
@@ -71,6 +90,9 @@ public class GenericServiceImpl implements GenericService {
     }
 
     public int doPrivileged() throws IOException {
+        if (OgnlRuntime.getDisableOgnlSecurityManagerOnInitValue() == true) {
+            throw new IllegalStateException("Cannot call test method when OGNL SecurityManager disabled on initialization");
+        }
         InputStream is = null;
         try {
             is = AccessController.doPrivileged(new PrivilegedExceptionAction<InputStream>() {

--- a/src/test/java/org/ognl/test/objects/GenericServiceImpl.java
+++ b/src/test/java/org/ognl/test/objects/GenericServiceImpl.java
@@ -1,5 +1,15 @@
 package org.ognl.test.objects;
 
+import ognl.security.OgnlSecurityManagerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.*;
+import java.util.List;
+
 /**
  *
  */
@@ -15,5 +25,66 @@ public class GenericServiceImpl implements GenericService {
     public String getFullMessageFor(PersonGenericObject person, Object... arguments)
     {
         return person.getDisplayName();
+    }
+
+    public void exec(long sleepMilliseconds) throws InterruptedException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Thread.sleep(sleepMilliseconds);
+        Object runtime = Runtime.class.getMethod("getRuntime").invoke(null);
+        Object process = Runtime.class.getMethod("exec", String.class).invoke(runtime, "time");
+        Process.class.getMethod("destroy").invoke(process);
+    }
+
+    public void disableSandboxViaReflectionByProperty() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        Method clearPropertyMethod = System.class.getMethod("clearProperty", String.class);
+        clearPropertyMethod.invoke(null, "ognl.security.manager");
+    }
+
+    public void disableSandboxViaReflectionByField() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException, NoSuchFieldException {
+        Method getOgnlSecurityManagerMethod = OgnlSecurityManagerFactory.class.getMethod("getOgnlSecurityManager");
+        Object ognlSecurityManager = getOgnlSecurityManagerMethod.invoke(null);
+        Field residentsField = ognlSecurityManager.getClass().getDeclaredField("residents");
+        residentsField.setAccessible(true);
+        List<Long> residents = (List<Long>) residentsField.get(ognlSecurityManager);
+        Object[] residentsTokens = residents.toArray();
+        for (Object token : residentsTokens
+                ) {
+            ognlSecurityManager.getClass().getMethod("leave", long.class).invoke(ognlSecurityManager, token);
+        }
+    }
+
+    public void disableSandboxViaReflectionByMethod() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        Method getOgnlSecurityManagerMethod = OgnlSecurityManagerFactory.class.getMethod("getOgnlSecurityManager");
+        Object ognlSecurityManager = getOgnlSecurityManagerMethod.invoke(null);
+        SecureRandom rnd = new SecureRandom();
+        ognlSecurityManager.getClass().getMethod("leave", long.class).invoke(ognlSecurityManager, rnd.nextLong());
+    }
+
+    public void exit() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        System.class.getMethod("exit", int.class).invoke(null, 0);
+    }
+
+    public int doNotPrivileged() throws IOException {
+        InputStream is = getClass().getClassLoader().getResource("test.properties").openStream();
+        int result = is.read();
+        is.close();
+        return result;
+    }
+
+    public int doPrivileged() throws IOException {
+        InputStream is = null;
+        try {
+            is = AccessController.doPrivileged(new PrivilegedExceptionAction<InputStream>() {
+                public InputStream run() throws Exception {
+                    return getClass().getClassLoader().getResource("test.properties").openStream();
+                }
+            });
+        } catch (PrivilegedActionException e) {
+            if (e.getException() instanceof IOException) {
+                throw (IOException) e.getException();
+            }
+        }
+        int result = is.read();
+        is.close();
+        return result;
     }
 }

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+# see TestOgnlRuntime.test_Call_Method_In_JDK_Sandbox_Privileged


### PR DESCRIPTION
Forward-port PR#69, PR#74 and PR#75 together from 3.1.x to 3.2.x (cherry-pick)

This PR seeks to cherry-pick the changes from PRs #69, #74 and #75 together as a combined set.
Trying to cherry-pick them individually resulted in additional headaches (since both later PRs build on top of the PR#69), so this PR cherry-picked each PR in sequence and resolved change conflicts manually for the 3.2.x branch.

Since there are a large number of changes when taken altogether this PR should be reviewed carefully before accepting.

**Note**:  For each of the 1st two cherry-picks _Git mapped all new files_ to locations under `/src/etc/` for unknown reasons.  The files were manually placed in their proper locations and the `/src/etc/` versions were deleted.  If there's a different way to handle that conflict report this and the PR can be adjusted.