### PR TITLE
DefaultClassResolver should resolve classes in the default package

### DIFF
--- a/src/main/java/ognl/DefaultClassResolver.java
+++ b/src/main/java/ognl/DefaultClassResolver.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class DefaultClassResolver extends Object implements ClassResolver
 {
-    private final Map<String, Class> classes = new ConcurrentHashMap<>(101);
+    private final ConcurrentHashMap<String, Class> classes = new ConcurrentHashMap<>(101);
 
     public DefaultClassResolver()
     {
@@ -55,8 +55,22 @@ public class DefaultClassResolver extends Object implements ClassResolver
         if (result != null) {
             return result;
         }
-        result = (className.indexOf('.') == -1) ? toClassForName("java.lang." + className) : toClassForName(className);
-        classes.put(className, result);
+        try {
+            result = toClassForName(className);
+        } catch (ClassNotFoundException e) {
+            if (className.indexOf('.') > -1) {
+                throw e;
+            }
+            // The class was not in the default package.
+            // Try prepending 'java.lang.'.
+            try {
+                result = toClassForName("java.lang." + className);
+            } catch (ClassNotFoundException e2) {
+                // Report the specified class name as-is.
+                throw e;
+            }
+        }
+        classes.putIfAbsent(className, result);
         return result;
     }
 

--- a/src/test/java/ClassInDefaultPackage.java
+++ b/src/test/java/ClassInDefaultPackage.java
@@ -1,0 +1,4 @@
+
+class ClassInDefaultPackage {
+    public static final int CONST = 99;
+}

--- a/src/test/java/ognl/DefaultClassResolverTest.java
+++ b/src/test/java/ognl/DefaultClassResolverTest.java
@@ -1,0 +1,41 @@
+package ognl;
+
+import junit.framework.TestCase;
+
+public class DefaultClassResolverTest extends TestCase {
+
+    public void testClassInDefaultPackageResolution() throws Exception {
+        DefaultClassResolver resolver = new DefaultClassResolver();
+        OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null,
+                new DefaultMemberAccess(false));
+        assertNotNull(resolver.classForName("ClassInDefaultPackage", context));
+    }
+
+    public void testEnsureClassNotFoundException() throws Exception {
+        DefaultClassResolver resolver = new DefaultClassResolver();
+        OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null,
+                new DefaultMemberAccess(false));
+        try {
+            resolver.classForName("no.such.Class", context);
+            fail("Expected ClassNotFoundException as the specified class does not exist.");
+        } catch (Exception e) {
+            assertEquals(ClassNotFoundException.class, e.getClass());
+            assertEquals("no.such.Class", e.getMessage());
+        }
+    }
+
+    public void testEnsureClassNotFoundExceptionReportsSpecifiedName()
+            throws Exception {
+        DefaultClassResolver resolver = new DefaultClassResolver();
+        OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null,
+                new DefaultMemberAccess(false));
+        try {
+            resolver.classForName("BogusClass", context);
+            fail("Expected ClassNotFoundException as the specified class does not exist.");
+        } catch (Exception e) {
+            assertEquals(ClassNotFoundException.class, e.getClass());
+            assertEquals("BogusClass", e.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
`DefaultClassResolver#classForName()` throws `ClassNotFoundException` if the specified class is in the default package (i.e. no dot in the className).
Using the default package should be avoided, but we have received a few bug reports about it.
https://github.com/mybatis/mybatis-3/issues/1524
https://github.com/mybatis/mybatis-3/issues/1768
And the reporters said that it was working fine with the older versions, so it probably is related to #46 .

To write a test, I had to create a class in the default package.
If you don't like it, I will remove the class along with the test.
The comment in the source might be good enough to avoid regression.
