### PR TITLE
Update source/target level for OGNL 3.1.x to JDK 1.7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,12 +78,12 @@
 
         <plugins>
             <plugin>
-                <!-- Raised source/target levels to 1.6 as Travis CI now rejects 1.5 -->
+                <!-- Raised source/target levels to 1.7 as Travis CI now rejects 1.5 -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
                 <executions>
                     <execution>
@@ -93,8 +93,8 @@
                             <goal>testCompile</goal>
                         </goals>
                         <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
+                            <source>1.7</source>
+                            <target>1.7</target>
                         </configuration>
                     </execution>
                 </executions>
@@ -102,7 +102,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>  <!-- Most recent 2.x available -->
+                <version>2.22.2</version>  <!-- Most recent 2.x available -->
                 <configuration>
                     <excludes>
                         <exclude>**/OgnlTestCase.java</exclude>
@@ -153,9 +153,9 @@
                         <compress>true</compress>
                         <index>true</index>
                     </archive>
-                    <source>1.6</source>
+                    <source>1.7</source>
                     <links>
-                        <link>http://docs.oracle.com/javase/6/docs/api/</link>
+                        <link>http://docs.oracle.com/javase/7/docs/api/</link>
                     </links>
                 </configuration>
                 <executions>

--- a/src/java/ognl/Ognl.java
+++ b/src/java/ognl/Ognl.java
@@ -104,7 +104,7 @@ public abstract class Ognl
      * @throws IllegalStateException
      *            if the expression maximum allowed length is frozen.
      * @throws IllegalArgumentException
-     *            if the provided expressionMaxLength is < 0.
+     *            if the provided expressionMaxLength is &lt; 0.
      * @since 3.1.26
      */
     public static synchronized void applyExpressionMaxLength(Integer expressionMaxLength) {


### PR DESCRIPTION
Update source/target level for OGNL 3.1.x to JDK 1.7.
- Update pom.xml with source/target 1.7 as per L. Lenart comment in PR#89.
- Update surefire plugin to latest 2.x available.
- Update javadoc comment in Ognl class causing build failure in JDK 8/11.