### PR TITLE
Forward-port PR#89 from 3.1.x to 3.2.x (cherry-pick).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>  <!-- Most recent 2.x available -->
+                <version>2.22.2</version>  <!-- Most recent 2.x available -->
                 <configuration>
                     <excludes>
                         <exclude>**/OgnlTestCase.java</exclude>
@@ -154,9 +154,9 @@
                         <compress>true</compress>
                         <index>true</index>
                     </archive>
-                    <source>1.6</source>
+                    <source>1.7</source>
                     <links>
-                        <link>http://docs.oracle.com/javase/6/docs/api/</link>
+                        <link>http://docs.oracle.com/javase/7/docs/api/</link>
                     </links>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,10 @@
                         <compress>true</compress>
                         <index>true</index>
                     </archive>
+                    <source>1.6</source>
+                    <links>
+                        <link>http://docs.oracle.com/javase/6/docs/api/</link>
+                    </links>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/ognl/ASTConst.java
+++ b/src/main/java/ognl/ASTConst.java
@@ -56,7 +56,11 @@ public class ASTConst extends SimpleNode implements NodeType
         super(p, id);
     }
 
-    /** Called from parser actions. */
+    /** 
+     * Called from parser actions.
+     *
+     * @param value the Object representing the value.
+     */
     public void setValue(Object value)
     {
         this.value = value;

--- a/src/main/java/ognl/ASTMethod.java
+++ b/src/main/java/ognl/ASTMethod.java
@@ -62,7 +62,11 @@ public class ASTMethod extends SimpleNode implements OrderedReturn, NodeType
         super(p, id);
     }
 
-    /** Called from parser action. */
+    /** 
+     * Called from parser action.
+     *
+     * @param methodName the method name.
+     */
     public void setMethodName(String methodName)
     {
         _methodName = methodName;
@@ -70,6 +74,8 @@ public class ASTMethod extends SimpleNode implements OrderedReturn, NodeType
 
     /**
      * Returns the method name that this node will call.
+     * 
+     * @return the method name.
      */
     public String getMethodName()
     {

--- a/src/main/java/ognl/ASTProperty.java
+++ b/src/main/java/ognl/ASTProperty.java
@@ -61,6 +61,8 @@ public class ASTProperty extends SimpleNode implements NodeType
 
     /**
      * Returns true if this property is itself an index reference.
+     * 
+     * @return true if this property is an index reference, false otherwise.
      */
     public boolean isIndexedAccess()
     {
@@ -71,6 +73,11 @@ public class ASTProperty extends SimpleNode implements NodeType
      * Returns true if this property is described by an IndexedPropertyDescriptor and that if
      * followed by an index specifier it will call the index get/set methods rather than go through
      * property accessors.
+     * 
+     * @param context the OgnlContext within which to perform the operation. 
+     * @param source the Object (indexed property) from which to retrieve the indexed property type.
+     * @return the int representing the indexed property type of source.
+     * @throws OgnlException if source is not an indexed property.
      */
     public int getIndexedPropertyType(OgnlContext context, Object source)
             throws OgnlException

--- a/src/main/java/ognl/AccessibleObjectHandler.java
+++ b/src/main/java/ognl/AccessibleObjectHandler.java
@@ -32,8 +32,8 @@ public abstract interface AccessibleObjectHandler
     /**
      * Provides an appropriate implementation to change the accessibility of accessibleObject.
      *
-     * @param accessibleObject
-     * @param flag
+     * @param accessibleObject the AccessibleObject upon which to apply the flag.
+     * @param flag the new accessible flag value.
      */
     void setAccessible(AccessibleObject accessibleObject, boolean flag);
 }

--- a/src/main/java/ognl/AccessibleObjectHandlerJDK9Plus.java
+++ b/src/main/java/ognl/AccessibleObjectHandlerJDK9Plus.java
@@ -60,7 +60,7 @@ class AccessibleObjectHandlerJDK9Plus implements AccessibleObjectHandler
      * Package-accessible method to determine if a given class is Unsafe or a descendant
      *   of Unsafe.
      *
-     * @param clazz
+     * @param clazz the Class upon which to perform the unsafe check.
      * @return true if parameter is Unsafe or a descendant, false otherwise
      */
     static boolean unsafeOrDescendant(final Class clazz) {
@@ -222,8 +222,8 @@ class AccessibleObjectHandlerJDK9Plus implements AccessibleObjectHandler
      * Utilize accessibility modification mechanism for JDK 9 (Java Major Version 9) and later.
      *   Should that mechanism fail, attempt a standard pre-JDK9 accessibility modification.
      *
-     * @param accessibleObject
-     * @param flag
+     * @param accessibleObject the AccessibleObject upon which to apply the flag.
+     * @param flag the new accessible flag value.
      */
     public void setAccessible(AccessibleObject accessibleObject, boolean flag) {
         boolean operationComplete = false;

--- a/src/main/java/ognl/AccessibleObjectHandlerPreJDK9.java
+++ b/src/main/java/ognl/AccessibleObjectHandlerPreJDK9.java
@@ -51,8 +51,8 @@ class AccessibleObjectHandlerPreJDK9 implements AccessibleObjectHandler
      * Utilize accessibility modification mechanism for JDK 8 (Java Major Version 8) and earlier.
      *   It is also the default modification mechanism for JDK 9+.
      *
-     * @param accessibleObject
-     * @param flag
+     * @param accessibleObject the AccessibleObject upon which to apply the flag.
+     * @param flag the new accessible flag value.
      */
     public void setAccessible(AccessibleObject accessibleObject, boolean flag) {
         accessibleObject.setAccessible(flag);

--- a/src/main/java/ognl/Evaluation.java
+++ b/src/main/java/ognl/Evaluation.java
@@ -51,6 +51,9 @@ public class Evaluation extends Object
 
     /**
         Constructs a new "get" <code>Evaluation</code> from the node and source given.
+     *
+     * @param node a SimpleNode for this Evaluation.
+     * @param source a source Object for this Evaluation.
      */
     public Evaluation(SimpleNode node, Object source)
     {
@@ -63,6 +66,10 @@ public class Evaluation extends Object
         Constructs a new <code>Evaluation</code> from the node and source given.
         If <code>setOperation</code> is true this <code>Evaluation</code> represents
         a "set" as opposed to a "get".
+     *
+     * @param node a SimpleNode for this Evaluation.
+     * @param source a source Object for this Evaluation.
+     * @param setOperation true to identify this Evaluation as a set operation, false to identify it as a get operation.
      */
     public Evaluation(SimpleNode node, Object source, boolean setOperation)
     {
@@ -72,6 +79,8 @@ public class Evaluation extends Object
 
     /**
         Returns the <code>SimpleNode</code> for this <code>Evaluation</code>
+     *
+     * @return the SimpleNode for this Evaluation.
      */
     public SimpleNode getNode()
     {
@@ -83,6 +92,8 @@ public class Evaluation extends Object
         set this.  Notable exceptions to this rule are custom evaluators that
         choose between navigable objects (as in a multi-root evaluator where
         the navigable node is chosen at runtime).
+     *
+     * @param value the SimpleNode to set for this Evaluation.
      */
     public void setNode(SimpleNode value)
     {
@@ -91,6 +102,8 @@ public class Evaluation extends Object
 
     /**
         Returns the source object on which this Evaluation operated.
+     *
+     * @return the source Object operated upon by this Evaluation.
      */
     public Object getSource()
     {
@@ -102,6 +115,8 @@ public class Evaluation extends Object
         set this.  Notable exceptions to this rule are custom evaluators that
         choose between navigable objects (as in a multi-root evaluator where
         the navigable node is chosen at runtime).
+     *
+     * @param value the source Object to be set for this Evaluation.
      */
     public void setSource(Object value)
     {
@@ -110,6 +125,8 @@ public class Evaluation extends Object
 
     /**
         Returns true if this Evaluation represents a set operation.
+     *
+     * @return true if this Evaluation represents a set operation, false otherwise.
      */
     public boolean isSetOperation()
     {
@@ -119,6 +136,8 @@ public class Evaluation extends Object
     /**
         Marks the Evaluation as a set operation if the value is true, else
         marks it as a get operation.
+     *
+     * @param value true to identify this Evaluation as a set operation, false to identify it as a get operation.
      */
     public void setSetOperation(boolean value)
     {
@@ -127,6 +146,8 @@ public class Evaluation extends Object
 
     /**
         Returns the result of the Evaluation, or null if it was a set operation.
+     *
+     * @return the result of the Evaluation (for a get operation), or null (for a set operation).
      */
     public Object getResult()
     {
@@ -136,6 +157,8 @@ public class Evaluation extends Object
     /**
         Sets the result of the Evaluation.  This method is normally only used
         interally and should not be set without knowledge of what you are doing.
+     *
+     * @param value the result Object for this Evaluation.
      */
     public void setResult(Object value)
     {
@@ -145,6 +168,8 @@ public class Evaluation extends Object
     /**
         Returns the exception that occurred as a result of evaluating the
         Evaluation, or null if no exception occurred.
+     * 
+     * @return an exception if one occurred during evaluation, or null (no exception) otherwise.
      */
     public Throwable getException()
     {
@@ -155,6 +180,8 @@ public class Evaluation extends Object
         Sets the exception that occurred as a result of evaluating the
         Evaluation.  This method is normally only used interally and
         should not be set without knowledge of what you are doing.
+     *
+     * @param value the Throwable exception that occurred during the evaluation of this Evaluation.
      */
     public void setException(Throwable value)
     {
@@ -164,6 +191,8 @@ public class Evaluation extends Object
     /**
         Returns the parent evaluation of this evaluation.  If this returns
         null then it is is the root evaluation of a tree.
+     *
+     * @return the parent Evaluation of the current Evaluation, or null if no parent exists.
      */
     public Evaluation getParent()
     {
@@ -173,6 +202,8 @@ public class Evaluation extends Object
     /**
         Returns the next sibling of this evaluation.  Returns null if
         this is the last in a chain of evaluations.
+     *
+     * @return the next sibling Evaluation of the current Evaluation, or null if this is the last Evaluation in a chain.
      */
     public Evaluation getNext()
     {
@@ -182,6 +213,8 @@ public class Evaluation extends Object
     /**
         Returns the previous sibling of this evaluation.  Returns null if
         this is the first in a chain of evaluations.
+     *
+     * @return the previous sibling Evaluation of the current Evaluation, or null if this is the first Evaluation in a chain.
      */
     public Evaluation getPrevious()
     {
@@ -191,6 +224,8 @@ public class Evaluation extends Object
     /**
         Returns the first child of this evaluation.  Returns null if
         there are no children.
+     *
+     * @return the first child Evaluation of the current Evaluation, or null if no children exist.
      */
     public Evaluation getFirstChild()
     {
@@ -200,6 +235,8 @@ public class Evaluation extends Object
     /**
         Returns the last child of this evaluation.  Returns null if
         there are no children.
+     *
+     * @return the last child Evaluation of the current Evaluation, or null if no children exist.
      */
     public Evaluation getLastChild()
     {
@@ -209,6 +246,8 @@ public class Evaluation extends Object
     /**
         Gets the first descendent.  In any Evaluation tree this will the
         Evaluation that was first executed.
+     *
+     * @return the first descendant Evaluation (first Evaluation executed in the tree).
      */
     public Evaluation getFirstDescendant()
     {
@@ -221,6 +260,8 @@ public class Evaluation extends Object
     /**
         Gets the last descendent.  In any Evaluation tree this will the
         Evaluation that was most recently executing.
+     *
+    * @return the last descendant Evaluation (most recent Evaluation executed in the tree).
      */
     public Evaluation getLastDescendant()
     {
@@ -236,6 +277,8 @@ public class Evaluation extends Object
         references are modified in the receiver to reflect the new child.
         The lastChild of the receiver is set to the child, and the
         firstChild is set also if child is the first (or only) child.
+     *
+     * @param child an Evaluation to add as a child to the current Evaluation.
      */
     public void addChild(Evaluation child)
     {
@@ -257,6 +300,10 @@ public class Evaluation extends Object
 
     /**
         Reinitializes this Evaluation to the parameters specified.
+     *
+     * @param node a SimpleNode for this Evaluation.
+     * @param source a source Object for this Evaluation.
+     * @param setOperation true to identify this Evaluation as a set operation, false to identify it as a get operation.
      */
     public void init(SimpleNode node, Object source, boolean setOperation)
     {
@@ -287,6 +334,11 @@ public class Evaluation extends Object
         description including source and result are shown.  If showChildren
         is true the child evaluations are printed using the depth string
         given as a prefix.
+     *
+     * @param compact true to generate a compact form of the description for this Evaluation, false for a full form.
+     * @param showChildren true to generate descriptions for child Evaluation elements of this Evaluation.
+     * @param depth prefix String to use in front of child Evaluation description output - used when showChildren is true.
+     * @return the description of this Evaluation as a String.
      */
     public String toString(boolean compact, boolean showChildren, String depth)
     {
@@ -318,6 +370,10 @@ public class Evaluation extends Object
         the node type and unique identifier is shown, else a full
         description including source and result are shown.  Child
         evaluations are printed using the depth string given as a prefix.
+     *
+     * @param compact true to generate a compact form of the description for this Evaluation, false for a full form.
+     * @param depth prefix String to use in front of child Evaluation description output - used when showChildren is true.
+     * @return the description of this Evaluation as a String.
      */
     public String toString(boolean compact, String depth)
     {
@@ -326,6 +382,8 @@ public class Evaluation extends Object
 
     /**
         Returns a String description of the Evaluation.
+     *
+     * @return the description of this Evaluation as a String.
      */
     public String toString()
     {

--- a/src/main/java/ognl/EvaluationPool.java
+++ b/src/main/java/ognl/EvaluationPool.java
@@ -49,6 +49,10 @@ public final class EvaluationPool extends Object
         Returns an Evaluation that contains the node, source and whether it
         is a set operation.  If there are no Evaluation objects in the
         pool one is created and returned.
+     *
+     * @param node a SimpleNode for an Evaluation to be created.
+     * @param source a source Object for an Evaluation to be created.
+     * @return an Evaluation based on the parameters.
      */
     public Evaluation create(SimpleNode node, Object source)
     {
@@ -58,6 +62,11 @@ public final class EvaluationPool extends Object
     /**
         Returns an Evaluation that contains the node, source and whether it
         is a set operation. 
+     *
+     * @param node a SimpleNode for an Evaluation to be created.
+     * @param source a source Object for an Evaluation to be created.
+     * @param setOperation true to identify the Evaluation to be created as a set operation, false to identify it as a get operation.
+     * @return an Evaluation based on the parameters.
      */
     public Evaluation create(SimpleNode node, Object source, boolean setOperation)
     {
@@ -67,6 +76,8 @@ public final class EvaluationPool extends Object
 
     /**
         Recycles an Evaluation
+     *
+     * @param value an Evaluation to be recycled (not used).
      * @deprecated object-pooling now relies on the jvm garbage collection
      */
     public void recycle(Evaluation value)
@@ -77,6 +88,8 @@ public final class EvaluationPool extends Object
     /**
         Recycles an of Evaluation and all of it's siblings
         and children.
+     *
+     * @param value an Evaluation to be recycled along with its siblings (not used).
      * @deprecated object-pooling now relies on the jvm garbage collection
      */
     public void recycleAll(Evaluation value)
@@ -86,6 +99,8 @@ public final class EvaluationPool extends Object
 
     /**
         Recycles a List of Evaluation objects
+     *
+     * @param value a List of Evaluation objects to be recycled (not used).
      * @deprecated object-pooling now relies on the jvm garbage collection
      */
     public void recycleAll(List value)
@@ -95,6 +110,8 @@ public final class EvaluationPool extends Object
 
     /**
         Returns the number of items in the pool
+     *
+     * @return the size of the Evaluation pool (always 0).
      * @deprecated object-pooling now relies on the jvm garbage collection
      */
     public int getSize()
@@ -105,6 +122,8 @@ public final class EvaluationPool extends Object
     /**
         Returns the number of items this pool has created since
         it's construction.
+     *
+     * @return the creation count for the Evaluation pool (always 0).
      * @deprecated object-pooling now relies on the jvm garbage collection
      */
     public int getCreatedCount()
@@ -115,6 +134,8 @@ public final class EvaluationPool extends Object
     /**
         Returns the number of items this pool has recovered from
         the pool since its construction.
+     *
+     * @return the recovered count for the Evaluation pool (always 0).
      * @deprecated object-pooling now relies on the jvm garbage collection
      */
     public int getRecoveredCount()
@@ -125,6 +146,8 @@ public final class EvaluationPool extends Object
     /**
         Returns the number of items this pool has recycled since
         it's construction.
+     *
+     * @return the recycled count for the Evaluation pool (always 0).
      * @deprecated object-pooling now relies on the jvm garbage collection
      */
     public int getRecycledCount()

--- a/src/main/java/ognl/JavaCharStream.java
+++ b/src/main/java/ognl/JavaCharStream.java
@@ -172,7 +172,12 @@ public class JavaCharStream
      return nextCharBuf[nextCharInd];
   }
 
-/** @return starting character for token. */
+  /**
+   * Begin processing a new token, returning the starting character for the token.
+   * 
+   * @return starting character for token.
+   * @throws java.io.IOException if the operation fails a read operation.
+   */
   public char BeginToken() throws java.io.IOException
   {     
      if (inBuf > 0)
@@ -252,7 +257,12 @@ public class JavaCharStream
      bufcolumn[bufpos] = column;
   }
 
-/** Read a character. */
+  /**
+   * Read a character.
+   * 
+   * @return the character that was read for processing.
+   * @throws java.io.IOException if the operation fails a read operation.
+   */
   public char readChar() throws java.io.IOException
   {
      if (inBuf > 0)
@@ -346,6 +356,9 @@ public class JavaCharStream
   }
 
   /**
+   * Get the current column number.
+   * 
+   * @return the current column number.
    * @deprecated 
    * @see #getEndColumn
    */
@@ -354,6 +367,9 @@ public class JavaCharStream
   }
 
   /**
+   * Get the current line number.
+   * 
+   * @return the current line number.
    * @deprecated 
    * @see #getEndLine
    */
@@ -361,27 +377,39 @@ public class JavaCharStream
      return bufline[bufpos];
   }
 
-/** Get end column. */
+  /**
+   * Get end column.
+   * 
+   * @return the end column number.
+   */
   public int getEndColumn() {
      return bufcolumn[bufpos];
   }
 
-/** Get end line. */
+  /**
+   * Get end line.
+   * 
+   * @return the end line number.
+   */
   public int getEndLine() {
      return bufline[bufpos];
   }
 
-/** @return column of token start */
+  /** @return column of token start */
   public int getBeginColumn() {
      return bufcolumn[tokenBegin];
   }
 
-/** @return line number of token start */
+  /** @return line number of token start */
   public int getBeginLine() {
      return bufline[tokenBegin];
   }
 
-/** Retreat. */
+  /**
+   * Retreat.
+   * 
+   * @param amount the amount to backup (retreat) in the stream.
+   */
   public void backup(int amount) {
 
     inBuf += amount;
@@ -389,7 +417,14 @@ public class JavaCharStream
        bufpos += bufsize;
   }
 
-/** Constructor. */
+  /** 
+   * Constructor.
+   * 
+   * @param dstream the datastream to read from.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   * @param buffersize the size of the initial buffer to use to process the dstream.
+   */
   public JavaCharStream(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
   {
@@ -404,19 +439,37 @@ public class JavaCharStream
     nextCharBuf = new char[4096];
   }
 
-/** Constructor. */
+  /** 
+   * Constructor.
+   * 
+   * @param dstream the datastream to read from.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   */
   public JavaCharStream(java.io.Reader dstream,
                                         int startline, int startcolumn)
   {
      this(dstream, startline, startcolumn, 4096);
   }
 
-/** Constructor. */
+  /** 
+   * Constructor.
+   * 
+   * @param dstream the datastream to read from.
+   */
   public JavaCharStream(java.io.Reader dstream)
   {
      this(dstream, 1, 1, 4096);
   }
-/** Reinitialise. */
+
+  /** 
+   * Reinitialise.
+   * 
+   * @param dstream the datastream to read from.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   * @param buffersize the size of the initial buffer to use to process the dstream.
+   */
   public void ReInit(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
   {
@@ -437,90 +490,184 @@ public class JavaCharStream
     nextCharInd = bufpos = -1;
   }
 
-/** Reinitialise. */
+  /** 
+   * Reinitialise.
+   * 
+   * @param dstream the datastream to read from.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   */
   public void ReInit(java.io.Reader dstream,
                                         int startline, int startcolumn)
   {
      ReInit(dstream, startline, startcolumn, 4096);
   }
 
-/** Reinitialise. */
+  /** 
+   * Reinitialise.
+   * 
+   * @param dstream the datastream to read from.
+   */
   public void ReInit(java.io.Reader dstream)
   {
      ReInit(dstream, 1, 1, 4096);
   }
-/** Constructor. */
+
+  /** 
+   * Constructor.
+   * 
+   * @param dstream the datastream to read from.
+   * @param encoding the encoding to use for the dstream.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   * @param buffersize the size of the initial buffer to use to process the dstream.
+   * @throws java.io.UnsupportedEncodingException if the chosen encoding is not supported.
+   */
   public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
   {
      this(encoding == null ? new java.io.InputStreamReader(dstream) : new java.io.InputStreamReader(dstream, encoding), startline, startcolumn, buffersize);
   }
 
-/** Constructor. */
+  /** 
+   * Constructor.
+   * 
+   * @param dstream the datastream to read from.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   * @param buffersize the size of the initial buffer to use to process the dstream.
+   */
   public JavaCharStream(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
   {
      this(new java.io.InputStreamReader(dstream), startline, startcolumn, 4096);
   }
 
-/** Constructor. */
+  /** 
+   * Constructor.
+   * 
+   * @param dstream the datastream to read from.
+   * @param encoding the encoding to use for the dstream.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   * @throws java.io.UnsupportedEncodingException if the chosen encoding is not supported.
+   */
   public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
                         int startcolumn) throws java.io.UnsupportedEncodingException
   {
      this(dstream, encoding, startline, startcolumn, 4096);
   }
 
-/** Constructor. */
+  /** 
+   * Constructor.
+   * 
+   * @param dstream the datastream to read from.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   */
   public JavaCharStream(java.io.InputStream dstream, int startline,
                         int startcolumn)
   {
      this(dstream, startline, startcolumn, 4096);
   }
 
-/** Constructor. */
+  /** 
+   * Constructor.
+   * 
+   * @param dstream the datastream to read from.
+   * @param encoding the encoding to use for the dstream.
+   * @throws java.io.UnsupportedEncodingException if the chosen encoding is not supported.
+   */
   public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
      this(dstream, encoding, 1, 1, 4096);
   }
 
-/** Constructor. */
+  /** 
+   * Constructor.
+   * 
+   * @param dstream the datastream to read from.
+   */
   public JavaCharStream(java.io.InputStream dstream)
   {
      this(dstream, 1, 1, 4096);
   }
 
-/** Reinitialise. */
+  /** 
+   * Reinitialise.
+   * 
+   * @param dstream the datastream to read from.
+   * @param encoding the encoding to use for the dstream.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   * @param buffersize the size of the initial buffer to use to process the dstream.
+   * @throws java.io.UnsupportedEncodingException if the chosen encoding is not supported.
+   */
   public void ReInit(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
   {
      ReInit(encoding == null ? new java.io.InputStreamReader(dstream) : new java.io.InputStreamReader(dstream, encoding), startline, startcolumn, buffersize);
   }
 
-/** Reinitialise. */
+  /** 
+   * Reinitialise.
+   * 
+   * @param dstream the datastream to read from.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   * @param buffersize the size of the initial buffer to use to process the dstream.
+   */
   public void ReInit(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
   {
      ReInit(new java.io.InputStreamReader(dstream), startline, startcolumn, buffersize);
   }
-/** Reinitialise. */
+
+  /** 
+   * Reinitialise.
+   * 
+   * @param dstream the datastream to read from.
+   * @param encoding the encoding to use for the dstream.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   * @throws java.io.UnsupportedEncodingException if the chosen encoding is not supported.
+   */
   public void ReInit(java.io.InputStream dstream, String encoding, int startline,
                      int startcolumn) throws java.io.UnsupportedEncodingException
   {
      ReInit(dstream, encoding, startline, startcolumn, 4096);
   }
-/** Reinitialise. */
+
+  /** 
+   * Reinitialise.
+   * 
+   * @param dstream the datastream to read from.
+   * @param startline the line number to start processing from.
+   * @param startcolumn the column number to start processing from.
+   */
   public void ReInit(java.io.InputStream dstream, int startline,
                      int startcolumn)
   {
      ReInit(dstream, startline, startcolumn, 4096);
   }
-/** Reinitialise. */
+
+  /** 
+   * Reinitialise.
+   * 
+   * @param dstream the datastream to read from.
+   * @param encoding the encoding to use for the dstream.
+   * @throws java.io.UnsupportedEncodingException if the chosen encoding is not supported.
+   */
   public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
      ReInit(dstream, encoding, 1, 1, 4096);
   }
 
-/** Reinitialise. */
+  /** 
+   * Reinitialise.
+   * 
+   * @param dstream the datastream to read from.
+   */
   public void ReInit(java.io.InputStream dstream)
   {
      ReInit(dstream, 1, 1, 4096);
@@ -536,7 +683,12 @@ public class JavaCharStream
                               new String(buffer, 0, bufpos + 1);
   }
 
-  /** @return suffix */
+  /**
+   * Get the suffix of the specified length.
+   * 
+   * @param len the length of the suffix to get.
+   * @return suffix
+   */
   public char[] GetSuffix(int len)
   {
      char[] ret = new char[len];
@@ -564,6 +716,9 @@ public class JavaCharStream
 
   /**
    * Method to adjust line and column numbers for the start of a token.
+   * 
+   * @param newLine the new line number for the start of a token.
+   * @param newCol the new column number for the start of a token.
    */
   public void adjustBeginLineColumn(int newLine, int newCol)
   {

--- a/src/main/java/ognl/JavaSource.java
+++ b/src/main/java/ognl/JavaSource.java
@@ -19,6 +19,8 @@ public interface JavaSource
      * it could be turned into a literal java expression to be compiled and
      * executed for {@link ExpressionAccessor#get(OgnlContext, Object)} calls.
      * 
+     * @param context the OgnlContext within which to perform the operation.
+     * @param target the Object from which to retrieve the get source string.
      * @return Literal java string representation of an object get.
      */
     String toGetSourceString(OgnlContext context, Object target);
@@ -28,7 +30,9 @@ public interface JavaSource
      * it could be turned into a literal java expression to be compiled and
      * executed for {@link ExpressionAccessor#get(OgnlContext, Object)} calls.
      * 
-     * @return Literal java string representation of an object get.
+     * @param context the OgnlContext within which to perform the operation.
+     * @param target the Object from which to retrieve the set source string.
+     * @return Literal java string representation of an object set.
      */
     String toSetSourceString(OgnlContext context, Object target);
 }

--- a/src/main/java/ognl/MemberAccess.java
+++ b/src/main/java/ognl/MemberAccess.java
@@ -45,18 +45,36 @@ import java.util.Map;
 public interface MemberAccess
 {
     /**
-        Sets the member up for accessibility
+     * Sets the member up for accessibility
+     * 
+     * @param context the current execution context.
+     * @param target the Object upon which to perform the setup operation.
+     * @param member the Member upon which to perform the setup operation.
+     * @param propertyName the property upon which to perform the setup operation.
+     * @return the Object representing the original accessibility state of the target prior to the setup operation.
      */
     public Object setup(Map context, Object target, Member member, String propertyName);
 
     /**
-        Restores the member from the previous setup call.
+     * Restores the member from the previous setup call.
+     * 
+     * @param context the current execution context.
+     * @param target the Object upon which to perform the setup operation.
+     * @param member the Member upon which to perform the setup operation.
+     * @param propertyName the property upon which to perform the setup operation.
+     * @param state the Object holding the state to restore (target state prior to the setup operation).
      */
     public void restore(Map context, Object target, Member member, String propertyName, Object state);
 
     /**
         Returns true if the given member is accessible or can be made accessible
         by this object.
+     * 
+     * @param context the current execution context.
+     * @param target the Object to test accessibility for.
+     * @param member the Member to test accessibility for.
+     * @param propertyName the property to test accessibility for.
+     * @return true if the target/member/propertyName is accessible in the context, false otherwise.
      */
-	public boolean isAccessible(Map context, Object target, Member member, String propertyName);
+    public boolean isAccessible(Map context, Object target, Member member, String propertyName);
 }

--- a/src/main/java/ognl/Node.java
+++ b/src/main/java/ognl/Node.java
@@ -55,19 +55,33 @@ public interface Node extends JavaSource
     public void jjtClose();
 
     /** This pair of methods are used to inform the node of its
-        parent. */
+        parent.
+     *
+     * @param n the Node to make the parent of this node.
+     */
     public void jjtSetParent(Node n);
     public Node jjtGetParent();
 
     /** This method tells the node to add its argument to the node's
-        list of children.  */
+        list of children.
+     *
+     * @param n the Node to add as a child of this node.
+     * @param i the position at which to add the child node.
+     */
     public void jjtAddChild(Node n, int i);
 
     /** This method returns a child node.  The children are numbered
-        from zero, left to right. */
+        from zero, left to right.
+     *
+     * @param i the position from which to get the child node.
+     * @return the child Node at position i.
+     */
     public Node jjtGetChild(int i);
 
-    /** Return the number of children the node has. */
+    /** Return the number of children the node has.
+     *
+     * @return the number of children for this node.
+     */
     public int jjtGetNumChildren();
 
 
@@ -76,12 +90,22 @@ public interface Node extends JavaSource
     /**
      * Extracts the value from the given source object that is appropriate for this node
      * within the given context.
+     * 
+     * @param context the OgnlContext within which to perform the operation.
+     * @param source the Object from which to get the value.
+     * @return the value from the source (as appropriate within the provided context).
+     * @throws OgnlException if the value get fails.
      */
     public Object getValue( OgnlContext context, Object source ) throws OgnlException;
 
     /**
      * Sets the given value in the given target as appropriate for this node within the
      * given context.
+     * 
+     * @param context the OgnlContext within which to perform the operation.
+     * @param target the Object upon which to set the value.
+     * @param value the Object representing the value to apply to the target.
+     * @throws OgnlException if the value set fails.
      */
     public void setValue( OgnlContext context, Object target, Object value ) throws OgnlException;
     

--- a/src/main/java/ognl/NullHandler.java
+++ b/src/main/java/ognl/NullHandler.java
@@ -43,12 +43,23 @@ public interface NullHandler
 {
     /**
         Method called on target returned null.
+     *
+     * @param context the current execution context.
+     * @param target the Object on which the method was called.
+     * @param methodName the name of the method which was called.
+     * @param args the arguments to the method that was called.
+     * @return the result Object containing the state of the method call that returned null.
      */
     public Object nullMethodResult(Map context, Object target, String methodName, Object[] args);
 
     /**
         Property in target evaluated to null.  Property can be a constant
         String property name or a DynamicSubscript.
+     *
+     * @param context the current execution context.
+     * @param target the Object to which the property belongs.
+     * @param property the property whose value evaluated to null.
+     * @return the result Object containing the state of the property that evaluated to null.
      */
     public Object nullPropertyValue(Map context, Object target, Object property);
 }

--- a/src/main/java/ognl/ObjectArrayPool.java
+++ b/src/main/java/ognl/ObjectArrayPool.java
@@ -99,6 +99,9 @@ public final class ObjectArrayPool extends Object
     }
 
     /**
+     * Recycle an array of Objects.
+     * 
+     * @param value an Object array to recycle (not used).
      * @deprecated object-pooling now relies on the jvm garbage collection
      */
     public void recycle(Object[] value)

--- a/src/main/java/ognl/ObjectIndexedPropertyDescriptor.java
+++ b/src/main/java/ognl/ObjectIndexedPropertyDescriptor.java
@@ -65,6 +65,7 @@ import java.lang.reflect.*;
  * following way:
  *</p>
  *<table>
+ *  <caption>OGNL Expression</caption>
  *  <tr><th>OGNL Expression</th>
  *      <th>Handling</th>
  *  </tr>

--- a/src/main/java/ognl/ObjectPropertyAccessor.java
+++ b/src/main/java/ognl/ObjectPropertyAccessor.java
@@ -49,6 +49,12 @@ public class ObjectPropertyAccessor implements PropertyAccessor {
 
     /**
      * Returns OgnlRuntime.NotFound if the property does not exist.
+     * 
+     * @param context the current execution context.
+     * @param target the object to get the property from.
+     * @param name the name of the property to get.
+     * @return the current value of the given property in the given object.
+     * @throws OgnlException if there is an error locating the property in the given object.
      */
     public Object getPossibleProperty(Map context, Object target, String name)
             throws OgnlException
@@ -74,6 +80,13 @@ public class ObjectPropertyAccessor implements PropertyAccessor {
 
     /**
      * Returns OgnlRuntime.NotFound if the property does not exist.
+     * 
+     * @param context the current execution context.
+     * @param target the object to set the property in.
+     * @param name the name of the property to set.
+     * @param value the new value for the property.
+     * @return the Object result of the property set operation.
+     * @throws OgnlException if there is an error setting the property in the given object.
      */
     public Object setPossibleProperty(Map context, Object target, String name, Object value)
             throws OgnlException

--- a/src/main/java/ognl/Ognl.java
+++ b/src/main/java/ognl/Ognl.java
@@ -104,7 +104,7 @@ public abstract class Ognl
      * @throws IllegalStateException
      *            if the expression maximum allowed length is frozen.
      * @throws IllegalArgumentException
-     *            if the provided expressionMaxLength is < 0.
+     *            if the provided expressionMaxLength is &lt; 0.
      * @since 3.1.26
      */
     public static synchronized void applyExpressionMaxLength(Integer expressionMaxLength) {

--- a/src/main/java/ognl/OgnlContext.java
+++ b/src/main/java/ognl/OgnlContext.java
@@ -103,6 +103,10 @@ public class OgnlContext extends Object implements Map
     /**
      * Constructs a new OgnlContext with the given class resolver, type converter and member access.
      * If any of these parameters is null the default will be used.
+     * 
+     * @param classResolver the ClassResolver for a new OgnlContext.
+     * @param typeConverter the TypeConverter for a new OgnlContext.
+     * @param memberAccess the MemberAccess for a new OgnlContext.
      */
     public OgnlContext(ClassResolver classResolver, TypeConverter typeConverter, MemberAccess memberAccess)
     {
@@ -241,6 +245,8 @@ public class OgnlContext extends Object implements Map
     /**
      * Returns true if the last evaluation that was done on this context is retained and available
      * through <code>getLastEvaluation()</code>. The default is true.
+     * 
+     * @return true if the last evaluation for this context is retained and available through <code>getLastEvaluation()</code>, false otherwise.
      */
     public boolean getKeepLastEvaluation()
     {
@@ -250,6 +256,8 @@ public class OgnlContext extends Object implements Map
     /**
      * Sets whether the last evaluation that was done on this context is retained and available
      * through <code>getLastEvaluation()</code>. The default is true.
+     * 
+     * @param value true if the last evaluation for this context should be retained and available through <code>getLastEvaluation()</code>, false otherwise.
      */
     public void setKeepLastEvaluation(boolean value)
     {
@@ -362,6 +370,8 @@ public class OgnlContext extends Object implements Map
     /**
      * Gets the current Evaluation from the top of the stack. This is the Evaluation that is in
      * process of evaluating.
+     * 
+     * @return the current Evaluation from the top of the stack (being evaluated).
      */
     public Evaluation getCurrentEvaluation()
     {
@@ -376,6 +386,8 @@ public class OgnlContext extends Object implements Map
     /**
      * Gets the root of the evaluation stack. This Evaluation contains the node representing the
      * root expression and the source is the root source object.
+     * 
+     * @return the root Evaluation from the stack (the root expression node).
      */
     public Evaluation getRootEvaluation()
     {
@@ -391,6 +403,9 @@ public class OgnlContext extends Object implements Map
      * Returns the Evaluation at the relative index given. This should be zero or a negative number
      * as a relative reference back up the evaluation stack. Therefore getEvaluation(0) returns the
      * current Evaluation.
+     * 
+     * @param relativeIndex the relative index for the Evaluation to retrieve from the stack (with 0 being the current Evaluation).  relativeIndex should be &lt;= 0.
+     * @return the Evaluation at relativeIndex, or null if relativeIndex is &gt; 0.
      */
     public Evaluation getEvaluation(int relativeIndex)
     {
@@ -408,6 +423,8 @@ public class OgnlContext extends Object implements Map
     /**
      * Pushes a new Evaluation onto the stack. This is done before a node evaluates. When evaluation
      * is complete it should be popped from the stack via <code>popEvaluation()</code>.
+     * 
+     * @param value the Evaluation to push onto the stack.
      */
     public void pushEvaluation(Evaluation value)
     {
@@ -422,6 +439,8 @@ public class OgnlContext extends Object implements Map
     /**
      * Pops the current Evaluation off of the top of the stack. This is done after a node has
      * completed its evaluation.
+     * 
+     * @return the Evaluation popped from the top of the stack.
      */
     public Evaluation popEvaluation()
     {

--- a/src/main/java/ognl/OgnlOps.java
+++ b/src/main/java/ognl/OgnlOps.java
@@ -61,7 +61,7 @@ public abstract class OgnlOps implements NumericTypes
      * @param v2
      *            second value to compare
      * @return integer describing the comparison between the two objects. A negative number
-     *         indicates that v1 < v2. Positive indicates that v1 > v2. Zero indicates v1 == v2.
+     *         indicates that v1 &lt; v2. Positive indicates that v1 &gt; v2. Zero indicates v1 == v2.
      * @throws IllegalArgumentException
      *             if the objects are both non-numeric yet of incompatible types or do not implement
      *             Comparable.
@@ -297,6 +297,8 @@ public abstract class OgnlOps implements NumericTypes
      * 
      * @param value
      *            an object to interpret as a String
+     * @param trim
+     *            true if result should be whitespace-trimmed, false otherwise.
      * @return the String value implied by the given object as returned by the toString() method, or
      *         "null" if the object is null.
      */

--- a/src/main/java/ognl/OgnlParser.java
+++ b/src/main/java/ognl/OgnlParser.java
@@ -8,9 +8,12 @@ package ognl;
 public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, OgnlParserConstants {/*@bgen(jjtree)*/
   protected JJTOgnlParserState jjtree = new JJTOgnlParserState();
 
-/**
- * This is the top-level construct of OGNL.
- */
+  /**
+   * This is the top-level construct of OGNL.
+   * 
+   * @return the Node representing the top-level expression.
+   * @throws ParseException if the expression parsing fails.
+   */
   final public Node topLevelExpression() throws ParseException {
     expression();
     jj_consume_token(0);
@@ -2172,10 +2175,12 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     }
   }
 
-/**
- * Apply an expression to all elements of a collection, creating a new collection
- * as the result.
- */
+  /**
+   * Apply an expression to all elements of a collection, creating a new collection
+   * as the result.
+   * 
+   * @throws ParseException if the application of the projection expression fails.
+   */
   final public void projection() throws ParseException {
                               /*@bgen(jjtree) Project */
   ASTProject jjtn000 = new ASTProject(JJTPROJECT);
@@ -2219,10 +2224,12 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     }
   }
 
-/**
- * Apply a boolean expression to all elements of a collection, creating a new collection
- * containing those elements for which the expression returned true.
- */
+  /**
+   * Apply a boolean expression to all elements of a collection, creating a new collection
+   * containing those elements for which the expression returned true.
+   * 
+   * @throws ParseException if the application of the select all expression fails.
+   */
   final public void selectAll() throws ParseException {
                             /*@bgen(jjtree) Select */
   ASTSelect jjtn000 = new ASTSelect(JJTSELECT);
@@ -2254,10 +2261,12 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     }
   }
 
-/**
- * Apply a boolean expression to all elements of a collection, creating a new collection
- * containing those elements for the first element for which the expression returned true.
- */
+  /**
+   * Apply a boolean expression to all elements of a collection, creating a new collection
+   * containing those elements for the first element for which the expression returned true.
+   * 
+   * @throws ParseException if the application of the select first expression fails.
+   */
   final public void selectFirst() throws ParseException {
                                    /*@bgen(jjtree) SelectFirst */
   ASTSelectFirst jjtn000 = new ASTSelectFirst(JJTSELECTFIRST);
@@ -2289,10 +2298,12 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     }
   }
 
-/**
- * Apply a boolean expression to all elements of a collection, creating a new collection
- * containing those elements for the first element for which the expression returned true.
- */
+  /**
+   * Apply a boolean expression to all elements of a collection, creating a new collection
+   * containing those elements for the last element for which the expression returned true.
+   * 
+   * @throws ParseException if the application of the select last expression fails.
+   */
   final public void selectLast() throws ParseException {
                                  /*@bgen(jjtree) SelectLast */
   ASTSelectLast jjtn000 = new ASTSelectLast(JJTSELECTLAST);
@@ -2952,11 +2963,21 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
   private boolean jj_rescan = false;
   private int jj_gc = 0;
 
-  /** Constructor with InputStream. */
+  /**
+   * Constructor with InputStream.
+   * 
+   * @param stream the InputStream to parse.
+   */
   public OgnlParser(java.io.InputStream stream) {
      this(stream, null);
   }
-  /** Constructor with InputStream and supplied encoding */
+
+  /**
+   * Constructor with InputStream and supplied encoding
+   * 
+  * @param stream the InputStream to parse.
+  * @param encoding the encoding to use for the stream.
+   */
   public OgnlParser(java.io.InputStream stream, String encoding) {
     try { jj_input_stream = new JavaCharStream(stream, encoding, 1, 1); } catch(java.io.UnsupportedEncodingException e) { throw new RuntimeException(e); }
     token_source = new OgnlParserTokenManager(jj_input_stream);
@@ -2967,11 +2988,21 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
-  /** Reinitialise. */
+  /** 
+   * Reinitialise.
+   * 
+  * @param stream the InputStream to parse.
+   */
   public void ReInit(java.io.InputStream stream) {
      ReInit(stream, null);
   }
-  /** Reinitialise. */
+
+  /** 
+   * Reinitialise.
+   * 
+   * @param stream the InputStream to parse.
+   * @param encoding the encoding to use for the stream.
+   */
   public void ReInit(java.io.InputStream stream, String encoding) {
     try { jj_input_stream.ReInit(stream, encoding, 1, 1); } catch(java.io.UnsupportedEncodingException e) { throw new RuntimeException(e); }
     token_source.ReInit(jj_input_stream);
@@ -2983,7 +3014,11 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
-  /** Constructor. */
+  /**
+   * Constructor.
+   * 
+   * @param stream the Reader to parse.
+   */
   public OgnlParser(java.io.Reader stream) {
     jj_input_stream = new JavaCharStream(stream, 1, 1);
     token_source = new OgnlParserTokenManager(jj_input_stream);
@@ -2994,7 +3029,11 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
-  /** Reinitialise. */
+  /** 
+   * Reinitialise.
+   * 
+   * @param stream the Reader to parse.
+   */
   public void ReInit(java.io.Reader stream) {
     jj_input_stream.ReInit(stream, 1, 1);
     token_source.ReInit(jj_input_stream);
@@ -3006,7 +3045,11 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
-  /** Constructor with generated Token Manager. */
+  /**
+   * Constructor with generated Token Manager.
+   * 
+   * @param tm the OgnParserTokenManager to use during parsing.
+   */
   public OgnlParser(OgnlParserTokenManager tm) {
     token_source = tm;
     token = new Token();
@@ -3016,7 +3059,11 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
-  /** Reinitialise. */
+  /** 
+   * Reinitialise.
+   * 
+   * @param tm the OgnParserTokenManager to use during parsing.
+   */
   public void ReInit(OgnlParserTokenManager tm) {
     token_source = tm;
     token = new Token();
@@ -3075,7 +3122,11 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
   }
 
 
-/** Get the next Token. */
+  /** 
+   * Get the next Token.
+   * 
+   * @return the next Token result from parsing.
+   */
   final public Token getNextToken() {
     if (token.next != null) token = token.next;
     else token = token.next = token_source.getNextToken();
@@ -3084,7 +3135,12 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     return token;
   }
 
-/** Get the specific Token. */
+  /** 
+   * Get the specific Token.
+   * 
+   * @param index specifies how far to scan ahead for the Token.
+   * @return the Token at the given index.
+   */
   final public Token getToken(int index) {
     Token t = jj_lookingAhead ? jj_scanpos : token;
     for (int i = 0; i < index; i++) {
@@ -3132,7 +3188,11 @@ public class OgnlParser/*@bgen(jjtree)*/implements OgnlParserTreeConstants, Ognl
     }
   }
 
-  /** Generate ParseException. */
+  /** 
+   * Generate ParseException.
+   * 
+   * @return a ParseException with information about current token parsing state.
+   */
   public ParseException generateParseException() {
     jj_expentries.clear();
     boolean[] la1tokens = new boolean[86];

--- a/src/main/java/ognl/OgnlParserTokenManager.java
+++ b/src/main/java/ognl/OgnlParserTokenManager.java
@@ -84,8 +84,14 @@ public class OgnlParserTokenManager implements OgnlParserConstants
 
   /** Debug output. */
   public  java.io.PrintStream debugStream = System.out;
-  /** Set debug output. */
+
+  /** 
+   * Set debug output.
+   * 
+   * @param ds the PrintStream to use for debugging output capture.
+   */
   public  void setDebugStream(java.io.PrintStream ds) { debugStream = ds; }
+
 private final int jjStopStringLiteralDfa_0(int pos, long active0, long active1)
 {
    switch (pos)
@@ -1360,20 +1366,34 @@ private final StringBuffer image = new StringBuffer();
 private int jjimageLen;
 private int lengthOfMatch;
 protected char curChar;
-/** Constructor. */
+
+/** 
+ * Constructor.
+ * 
+ * @param stream the JavaCharStream to parse.
+ */
 public OgnlParserTokenManager(JavaCharStream stream){
    if (JavaCharStream.staticFlag)
       throw new Error("ERROR: Cannot use a static CharStream class with a non-static lexical analyzer.");
    input_stream = stream;
 }
 
-/** Constructor. */
+/** 
+ * Constructor.
+ * 
+ * @param stream the JavaCharStream to parse.
+ * @param lexState the lexical state to use for the OgnlParserTokenManager instance.
+ */
 public OgnlParserTokenManager(JavaCharStream stream, int lexState){
    this(stream);
    SwitchTo(lexState);
 }
 
-/** Reinitialise parser. */
+/** 
+ * Reinitialise parser.
+ * 
+ * @param stream the JavaCharStream to parse.
+ */
 public void ReInit(JavaCharStream stream)
 {
    jjmatchedPos = jjnewStateCnt = 0;
@@ -1389,14 +1409,24 @@ private void ReInitRounds()
       jjrounds[i] = 0x80000000;
 }
 
-/** Reinitialise parser. */
+/** 
+ * Reinitialise parser.
+ * 
+ * @param stream the JavaCharStream to parse.
+ * @param lexState the lexical state to use for the OgnlParserTokenManager instance.
+ */
 public void ReInit(JavaCharStream stream, int lexState)
 {
    ReInit(stream);
    SwitchTo(lexState);
 }
 
-/** Switch to specified lex state. */
+/**
+ * Switch to specified lex state.
+ * 
+ * @param lexState the lexical state (0 to 3) to use for the OgnlParserTokenManager instance.
+ * @throws TokenMgrError (an unchecked Error exception) if the lexical state is invalid.
+ */
 public void SwitchTo(int lexState)
 {
    if (lexState >= 4 || lexState < 0)
@@ -1436,7 +1466,11 @@ int jjround;
 int jjmatchedPos;
 int jjmatchedKind;
 
-/** Get the next Token. */
+/** 
+ * Get the next Token.
+ * 
+ * @return the next Token parsed from the stream.
+ */
 public Token getNextToken() 
 {
   Token matchedToken;

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -50,10 +50,10 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <ul>
  * <li>Handles majority of reflection logic / caching. </li>
- * <li>Utility methods for casting strings / various numeric types used by {@link OgnlExpressionCompiler}.</li.
+ * <li>Utility methods for casting strings / various numeric types used by {@link OgnlExpressionCompiler}.</li>
  * <li>Core runtime configuration point for setting/using global {@link TypeConverter} / {@link OgnlExpressionCompiler} /
  * {@link NullHandler} instances / etc.. </li>
- *</ul>
+ * </ul>
  *
  * @author Luke Blanshard (blanshlu@netscape.net)
  * @author Drew Davidson (drew@ognl.org)
@@ -642,7 +642,7 @@ public class OgnlRuntime {
     }
 
     /**
-     * Checks if the current jvm is java language >= 1.5 compatible.
+     * Checks if the current jvm is java language &gt;= 1.5 compatible.
      *
      * @return True if jdk15 features are present.
      */
@@ -720,6 +720,9 @@ public class OgnlRuntime {
      * Gets the "target" class of an object for looking up accessors that are registered on the
      * target. If the object is a Class object this will return the Class itself, else it will
      * return object's getClass() result.
+     * 
+     * @param o the Object from which to retrieve its Class.
+     * @return the Class of o.
      */
     public static Class getTargetClass(Object o)
     {
@@ -729,6 +732,9 @@ public class OgnlRuntime {
     /**
      * Returns the base name (the class name without the package name prepended) of the object
      * given.
+     * 
+     * @param o the Object from which to retrieve its base classname.
+     * @return the base classname of o's Class.
      */
     public static String getBaseName(Object o)
     {
@@ -737,6 +743,9 @@ public class OgnlRuntime {
 
     /**
      * Returns the base name (the class name without the package name prepended) of the class given.
+     * 
+     * @param c the Class from which to retrieve its name.
+     * @return the base classname of c.
      */
     public static String getClassBaseName(Class c)
     {
@@ -762,6 +771,9 @@ public class OgnlRuntime {
 
     /**
      * Returns the package name of the object's class.
+     * 
+     * @param o the Object from which to retrieve its Class package name.
+     * @return the package name of o's Class.
      */
     public static String getPackageName(Object o)
     {
@@ -770,6 +782,9 @@ public class OgnlRuntime {
 
     /**
      * Returns the package name of the class given.
+     * 
+     * @param c the Class from which to retrieve its package name.
+     * @return the package name of c.
      */
     public static String getClassPackageName(Class c)
     {
@@ -780,7 +795,10 @@ public class OgnlRuntime {
     }
 
     /**
-     * Returns a "pointer" string in the usual format for these things - 0x<hex digits>.
+     * Returns a "pointer" string in the usual format for these things - 0x&lt;hex digits&gt;.
+     * 
+     * @param num the int to convert into a "pointer" string in hex format.
+     * @return the String representing num as a "pointer" string in hex format.
      */
     public static String getPointerString(int num)
     {
@@ -804,8 +822,11 @@ public class OgnlRuntime {
     }
 
     /**
-     * Returns a "pointer" string in the usual format for these things - 0x<hex digits> for the
+     * Returns a "pointer" string in the usual format for these things - 0x&lt;hex digits&gt; for the
      * object given. This will always return a unique value for each object.
+     * 
+     * @param o the Object to convert into a "pointer" string in hex format.
+     * @return the String representing o as a "pointer" string in hex format.
      */
     public static String getPointerString(Object o)
     {
@@ -816,6 +837,10 @@ public class OgnlRuntime {
      * Returns a unique descriptor string that includes the object's class and a unique integer
      * identifier. If fullyQualified is true then the class name will be fully qualified to include
      * the package name, else it will be just the class' base name.
+     * 
+     * @param object the Object for which a unique descriptor string is desired.
+     * @param fullyQualified true if the descriptor string is fully-qualified (package name), false for just the Class' base name.
+     * @return the unique descriptor String for the object, qualified as per fullyQualified parameter.
      */
     public static String getUniqueDescriptor(Object object, boolean fullyQualified)
     {
@@ -841,6 +866,9 @@ public class OgnlRuntime {
     /**
      * Returns a unique descriptor string that includes the object's class' base name and a unique
      * integer identifier.
+     * 
+     * @param object the Object for which a unique descriptor string is desired.
+     * @return the unique descriptor String for the object, NOT fully-qualified.
      */
     public static String getUniqueDescriptor(Object object)
     {
@@ -851,6 +879,9 @@ public class OgnlRuntime {
      * Utility to convert a List into an Object[] array. If the list is zero elements this will
      * return a constant array; toArray() on List always returns a new object and this is wasteful
      * for our purposes.
+     * 
+     * @param list the List to convert into an Object array.
+     * @return the array of Objects from the list.
      */
     public static Object[] toArray(List list)
     {
@@ -870,6 +901,9 @@ public class OgnlRuntime {
 
     /**
      * Returns the parameter types of the given method.
+     * 
+     * @param m the Method whose parameter types are being queried.
+     * @return the array of Class elements representing m's parameters.  May be null if m does not utilize parameters.
      */
     public static Class[] getParameterTypes(Method m)
     {
@@ -888,7 +922,7 @@ public class OgnlRuntime {
     /**
      * Finds the appropriate parameter types for the given {@link Method} and
      * {@link Class} instance of the type the method is associated with.  Correctly
-     * finds generic types if running in >= 1.5 jre as well.
+     * finds generic types if running in &gt;= 1.5 jre as well.
      *
      * @param type The class type the method is being executed against.
      * @param m The method to find types for.
@@ -1041,6 +1075,9 @@ public class OgnlRuntime {
 
     /**
      * Returns the parameter types of the given method.
+     * 
+     * @param c the Constructor whose parameter types are being queried.
+     * @return the array of Class elements representing c's parameters.  May be null if c does not utilize parameters.
      */
     public static Class[] getParameterTypes(Constructor c)
     {
@@ -1076,7 +1113,10 @@ public class OgnlRuntime {
     }
 
     /**
-     * Permission will be named "invoke.<declaring-class>.<method-name>".
+     * Permission will be named "invoke.&lt;declaring-class&gt;.&lt;method-name&gt;".
+     * 
+     * @param method the Method whose Permission is being requested.
+     * @return the Permission for method named "invoke.&lt;declaring-class&gt;.&lt;method-name&gt;".
      */
     public static Permission getPermission(Method method)
     {
@@ -1320,6 +1360,10 @@ public class OgnlRuntime {
      * given object can be passed as an argument to a method or constructor whose parameter type is
      * the given class. If object is null this will return true because null is compatible with any
      * type.
+     * 
+     * @param object the Object to check for type-compatibility with Class c.
+     * @param c the Class for which object's type-compatibility is being checked.
+     * @return true if object is type-compatible with c.
      */
     public static final boolean isTypeCompatible(Object object, Class c) {
         if (object == null)
@@ -1498,6 +1542,10 @@ public class OgnlRuntime {
     /**
      * Tells whether the first array of classes is more specific than the second. Assumes that the
      * two arrays are of the same length.
+     * 
+     * @param classes1 the Class array being checked to see if it is "more specific" than classes2.
+     * @param classes2 the Class array that classes1 is being checked against to see if classes1 is "more specific" than classes2.
+     * @return true if the classes1 Class contents are "more specific" than classes2 Class contents, false otherwise.
      */
     public static final boolean isMoreSpecific(Class[] classes1, Class[] classes2)
     {
@@ -1645,6 +1693,7 @@ public class OgnlRuntime {
      * @param source Target object to run against or method name.
      * @param target Instance of object to be run against.
      * @param propertyName Name of property to get method of.
+     * @param methodName Name of the method to get from known methods.
      * @param methods List of current known methods.
      * @param args Arguments originally passed in.
      * @param actualArgs Converted arguments.
@@ -2057,6 +2106,15 @@ public class OgnlRuntime {
 
     /**
      * Don't use this method as it doesn't check member access rights via {@link MemberAccess} interface
+     * 
+     * @param context the current execution context.
+     * @param target the object to invoke the property name get on.
+     * @param propertyName the name of the property to be retrieved from target.
+     * @return the result invoking property retrieval of propertyName for target.
+     * @throws OgnlException for lots of different reasons.
+     * @throws IllegalAccessException if access not permitted.
+     * @throws NoSuchMethodException if no property accessor exists.
+     * @throws IntrospectionException on errors using {@link Introspector}.
      */
     @Deprecated
     public static final Object getMethodValue(OgnlContext context, Object target, String propertyName)
@@ -2069,6 +2127,16 @@ public class OgnlRuntime {
      * If the checkAccessAndExistence flag is true this method will check to see if the method
      * exists and if it is accessible according to the context's MemberAccess. If neither test
      * passes this will return NotFound.
+     * 
+     * @param context the current execution context.
+     * @param target the object to invoke the property name get on.
+     * @param propertyName the name of the property to be retrieved from target.
+     * @param checkAccessAndExistence true if this method should check access levels and existence for propertyName of target, false otherwise.
+     * @return the result invoking property retrieval of propertyName for target.
+     * @throws OgnlException for lots of different reasons.
+     * @throws IllegalAccessException if access not permitted.
+     * @throws NoSuchMethodException if no property accessor exists.
+     * @throws IntrospectionException on errors using {@link Introspector}.
      */
     public static final Object getMethodValue(OgnlContext context, Object target, String propertyName,
                                               boolean checkAccessAndExistence)
@@ -2102,6 +2170,16 @@ public class OgnlRuntime {
 
     /**
      * Don't use this method as it doesn't check member access rights via {@link MemberAccess} interface
+     * 
+     * @param context the current execution context.
+     * @param target the object to invoke the property name get on.
+     * @param propertyName the name of the property to be set for target.
+     * @param value the value to set for propertyName of target.
+     * @return true if the operation succeeded, false otherwise.
+     * @throws OgnlException for lots of different reasons.
+     * @throws IllegalAccessException if access not permitted.
+     * @throws NoSuchMethodException if no property accessor exists.
+     * @throws IntrospectionException on errors using {@link Introspector}.
      */
     @Deprecated
     public static boolean setMethodValue(OgnlContext context, Object target, String propertyName, Object value)
@@ -2381,6 +2459,12 @@ public class OgnlRuntime {
 
     /**
      * Don't use this method as it doesn't check member access rights via {@link MemberAccess} interface
+     * 
+     * @param context the current execution context.
+     * @param target the object to invoke the property name get on.
+     * @param propertyName the name of the property to be set for target.
+     * @return the result invoking field retrieval of propertyName for target.
+     * @throws NoSuchFieldException if the field does not exist.
      */
     @Deprecated
     public static Object getFieldValue(OgnlContext context, Object target, String propertyName)
@@ -2474,17 +2558,17 @@ public class OgnlRuntime {
 
     /**
      * Method name is getStaticField(), but actually behaves more like "getStaticFieldValue()".
-     * <p/>
+     * <p>
      * Typical usage: Returns the value (not the actual {@link Field}) for the given (static) fieldName.
      * May return the {@link Enum} constant value for the given fieldName when className is an {@link Enum}.
      * May return a {@link Class} instance when the given fieldName is "class".
-     * <p/>
+     * </p>
      * @param context    The current ognl context
      * @param className  The name of the class which contains the field
      * @param fieldName  The name of the field whose value should be returned
      * 
      * @return           The value of the (static) fieldName
-     * @throws OgnlException
+     * @throws OgnlException for lots of different reasons.
      */
     public static Object getStaticField(OgnlContext context, String className, String fieldName)
             throws OgnlException
@@ -2670,6 +2754,13 @@ public class OgnlRuntime {
 
     /**
      * cache get methods
+     * 
+     * @param context the current execution context.
+     * @param targetClass the Class to invoke the property name "getter" retrieval on.
+     * @param propertyName the name of the property for which a "getter" is sought.
+     * @return the Method representing a "getter" for propertyName of targetClass.
+     * @throws OgnlException for lots of different reasons.
+     * @throws IntrospectionException on errors using {@link Introspector}.
      */
     public static Method getGetMethod(OgnlContext context, Class targetClass, String propertyName)
             throws IntrospectionException, OgnlException
@@ -2764,6 +2855,13 @@ public class OgnlRuntime {
 
     /**
      * cache set methods method
+     * 
+     * @param context the current execution context.
+     * @param targetClass the Class to invoke the property name "setter" retrieval on.
+     * @param propertyName the name of the property for which a "setter" is sought.
+     * @return the Method representing a "setter" for propertyName of targetClass.
+     * @throws IntrospectionException on errors using {@link Introspector}.
+     * @throws OgnlException for lots of different reasons.
      */
     public static Method getSetMethod(OgnlContext context, Class targetClass, String propertyName)
             throws IntrospectionException, OgnlException
@@ -3030,6 +3128,12 @@ public class OgnlRuntime {
     /**
      * This method returns a PropertyDescriptor for the given class and property name using a Map
      * lookup (using getPropertyDescriptorsMap()).
+     * 
+     * @param targetClass the class to get the descriptors for.
+     * @param propertyName the property name of targetClass for which a Descriptor is requested.
+     * @return the PropertyDescriptor for propertyName of targetClass.
+     * @throws IntrospectionException on errors using {@link Introspector}.
+     * @throws OgnlException On general errors.
      */
     public static PropertyDescriptor getPropertyDescriptor(Class targetClass, String propertyName)
             throws IntrospectionException, OgnlException
@@ -3087,6 +3191,7 @@ public class OgnlRuntime {
      * @param name        Name of property
      * @return PropertyDescriptor of the named property or null if the class has no property with
      *         the given name
+     * @throws IntrospectionException on errors using {@link Introspector}.
      */
     public static PropertyDescriptor getPropertyDescriptorFromArray(Class targetClass, String name)
             throws IntrospectionException
@@ -3254,6 +3359,12 @@ public class OgnlRuntime {
      * then this will return whether it is a JavaBeans indexed property, conforming to the indexed
      * property patterns (returns <code>INDEXED_PROPERTY_INT</code>) or if it conforms to the
      * OGNL arbitrary object indexable (returns <code>INDEXED_PROPERTY_OBJECT</code>).
+     * 
+     * @param context the current execution context.
+     * @param sourceClass the Class to invoke indexed property type retrieval on.
+     * @param name the name of the property for which an indexed property type is sought.
+     * @return the indexed property type (int) for the property name of sourceClass. Returns <code>INDEXED_PROPERTY_NONE</code> if name is not an indexed property.
+     * @throws OgnlException for lots of different reasons.
      */
     public static int getIndexedPropertyType(OgnlContext context, Class sourceClass, String name)
             throws OgnlException
@@ -3684,14 +3795,13 @@ public class OgnlRuntime {
     /**
      * Compares the {@link OgnlContext#getCurrentType()} and {@link OgnlContext#getPreviousType()} class types
      * on the stack to determine if a numeric expression should force object conversion.
-     * <p/>
-     * <p/>
+     * <p>
      * Normally used in conjunction with the <code>forceConversion</code> parameter of
      * {@link OgnlRuntime#getChildSource(OgnlContext,Object,Node,boolean)}.
      * </p>
      *
      * @param context The current context.
-     * @return True, if the class types on the stack wouldn't be comparable in a pure numeric expression such as <code>o1 >= o2</code>.
+     * @return True, if the class types on the stack wouldn't be comparable in a pure numeric expression such as <code>o1 &gt;= o2</code>.
      */
     public static boolean shouldConvertNumericTypes(OgnlContext context)
     {
@@ -3995,7 +4105,6 @@ public class OgnlRuntime {
      *
      * @since 3.1.25
      *
-     * @return
      */
     public static boolean getDisableOgnlSecurityManagerOnInitValue() {
         return _disableOgnlSecurityManagerOnInit;

--- a/src/main/java/ognl/ParseException.java
+++ b/src/main/java/ognl/ParseException.java
@@ -23,7 +23,11 @@ public class ParseException extends Exception {
    * This constructor calls its super class with the empty string
    * to force the "toString" method of parent class "Throwable" to
    * print the error message in the form:
-   *     ParseException: <result of getMessage>
+   *     ParseException: &lt;result of getMessage&gt;
+   * 
+   * @param currentTokenVal the current Token being processed.
+   * @param expectedTokenSequencesVal the int[] array containing the expected token sequence values.
+   * @param tokenImageVal the Token Image value array providing additional state information about the parse failure.
    */
   public ParseException(Token currentTokenVal,
                         int[][] expectedTokenSequencesVal,
@@ -52,7 +56,11 @@ public class ParseException extends Exception {
     specialConstructor = false;
   }
 
-  /** Constructor with message. */
+  /** 
+   * Constructor with message.
+   * 
+   * @param message a simple String message indicating the type of parse failure.
+   */
   public ParseException(String message) {
     super(message);
     specialConstructor = false;
@@ -95,6 +103,8 @@ public class ParseException extends Exception {
    * from the parser), then this method is called during the printing
    * of the final stack trace, and hence the correct error message
    * gets displayed.
+   * 
+   * @return a String message describing the conditions of a parse failure.
    */
   public String getMessage() {
     if (!specialConstructor) {
@@ -148,6 +158,9 @@ public class ParseException extends Exception {
    * Used to convert raw characters to their escaped version
    * when these raw version cannot be used as part of an ASCII
    * string literal.
+   * 
+   * @param str the String to which escape sequences should be applied.
+   * @return the String result of str after undergoing escaping.
    */
   protected String add_escapes(String str) {
       StringBuffer retval = new StringBuffer();

--- a/src/main/java/ognl/SimpleNode.java
+++ b/src/main/java/ognl/SimpleNode.java
@@ -261,7 +261,14 @@ public abstract class SimpleNode implements Node, Serializable {
         return result;
     }
 
-    /** Subclasses implement this method to do the actual work of extracting the appropriate value from the source object. */
+    /**
+     * Subclasses implement this method to do the actual work of extracting the appropriate value from the source object.
+     * 
+     * @param context the OgnlContext within which to perform the operation.
+     * @param source the Object from which to get the value body.
+     * @return the value body from the source (as appropriate within the provided context).
+     * @throws OgnlException if the value body get fails.
+     */
     protected abstract Object getValueBody(OgnlContext context, Object source)
             throws OgnlException;
 
@@ -305,6 +312,11 @@ public abstract class SimpleNode implements Node, Serializable {
     /**
      * Subclasses implement this method to do the actual work of setting the appropriate value in the target object. The default implementation throws an
      * <code>InappropriateExpressionException</code>, meaning that it cannot be a set expression.
+     * 
+     * @param context the OgnlContext within which to perform the operation.
+     * @param target the Object upon which to set the value body.
+     * @param value the Object representing the value body to apply to the target.
+     * @throws OgnlException if the value body set fails.
      */
     protected void setValueBody(OgnlContext context, Object target, Object value)
             throws OgnlException
@@ -312,7 +324,13 @@ public abstract class SimpleNode implements Node, Serializable {
         throw new InappropriateExpressionException(this);
     }
 
-    /** Returns true iff this node is constant without respect to the children. */
+    /** 
+     * Returns true iff this node is constant without respect to the children.
+     * 
+     * @param context the OgnlContext within which to perform the operation.
+     * @return true if this node is a constant, false otherwise.
+     * @throws OgnlException if the check fails.
+     */
     public boolean isNodeConstant(OgnlContext context)
             throws OgnlException
     {

--- a/src/main/java/ognl/Token.java
+++ b/src/main/java/ognl/Token.java
@@ -60,6 +60,8 @@ public class Token {
    * interpreter. This attribute value is often different from the image.
    * Any subclass of Token that actually wants to return a non-null value can
    * override this method as appropriate.
+   * 
+   * @return the optional attribute value of this Token.
    */
   public Object getValue() {
     return null;
@@ -72,6 +74,8 @@ public class Token {
 
   /**
    * Constructs a new token for the specified Image.
+   * 
+   * @param kind the token Kind.
    */
   public Token(int kind)
   {
@@ -80,6 +84,9 @@ public class Token {
 
   /**
    * Constructs a new token for the specified Image and Kind.
+   * 
+   * @param kind the token Kind.
+   * @param image the token Image String.
    */
   public Token(int kind, String image)
   {
@@ -106,6 +113,10 @@ public class Token {
    *
    * to the following switch statement. Then you can cast matchedToken
    * variable to the appropriate type and use sit in your lexical actions.
+   * 
+   * @param ofKind the token Kind.
+   * @param image the token Image String.
+   * @return a new Token of Kind ofKind with Image image.
    */
   public static Token newToken(int ofKind, String image)
   {

--- a/src/main/java/ognl/TokenMgrError.java
+++ b/src/main/java/ognl/TokenMgrError.java
@@ -39,6 +39,9 @@ public class TokenMgrError extends Error
    /**
     * Replaces unprintable characters by their escaped (or unicode escaped)
     * equivalents in the given string
+    * 
+   * @param str the String to which escape sequences should be applied.
+   * @return the String result of str after undergoing escaping.
     */
    protected static final String addEscapes(String str) {
       StringBuffer retval = new StringBuffer();
@@ -96,6 +99,14 @@ public class TokenMgrError extends Error
     *    errorAfter  : prefix that was seen before this error occurred
     *    curchar     : the offending character
     * Note: You can customize the lexical error message by modifying this method.
+    * 
+   * @param EOFSeen indicates if EOF caused the lexical error.
+   * @param lexState the lexical state in which this error occurred.
+   * @param errorLine the line number when the error occurred.
+   * @param errorColumn the column number when the error occurred.
+   * @param errorAfter the prefix that was seen before this error occurred.
+   * @param curChar the offending character that produced the lexical error.
+   * @return the detail message String for the Error based on the provided parameters.
     */
    protected static String LexicalError(boolean EOFSeen, int lexState, int errorLine, int errorColumn, String errorAfter, char curChar) {
       return("Lexical error at line " +
@@ -113,6 +124,8 @@ public class TokenMgrError extends Error
     *     "Internal Error : Please file a bug report .... "
     *
     * from this method for such cases in the release version of your parser.
+    * 
+    * @return the error message for this TokenMgrError (typically the detailed error message).
     */
    public String getMessage() {
       return super.getMessage();
@@ -126,13 +139,28 @@ public class TokenMgrError extends Error
    public TokenMgrError() {
    }
 
-   /** Constructor with message and reason. */
+   /** 
+    * Constructor with message and reason.
+    * 
+    * @param message the error message String for this error.
+    * @param reason the reason code for this error.
+    */
    public TokenMgrError(String message, int reason) {
       super(message);
       errorCode = reason;
    }
 
-   /** Full Constructor. */
+   /** 
+    * Full Constructor.
+    * 
+    * @param EOFSeen indicates if EOF caused the lexical error.
+    * @param lexState the lexical state in which this error occurred.
+    * @param errorLine the line number when the error occurred.
+    * @param errorColumn the column number when the error occurred.
+    * @param errorAfter the prefix that was seen before this error occurred.
+    * @param curChar the offending character that produced the lexical error.
+    * @param reason the reason code for this error.
+    */
    public TokenMgrError(boolean EOFSeen, int lexState, int errorLine, int errorColumn, String errorAfter, char curChar, int reason) {
       this(LexicalError(EOFSeen, lexState, errorLine, errorColumn, errorAfter, curChar), reason);
    }

--- a/src/main/java/ognl/enhance/ExpressionCompiler.java
+++ b/src/main/java/ognl/enhance/ExpressionCompiler.java
@@ -66,7 +66,7 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
     /**
      * Returns the appropriate casting expression (minus parens) for the specified class type.
      *
-     * <p/>
+     * <p>
      * For instance, if given an {@link Integer} object the string <code>"java.lang.Integer"</code>
      * would be returned. For an array of primitive ints <code>"int[]"</code> and so on..
      * </p>
@@ -260,7 +260,7 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
     }
 
     /**
-     * Helper utility method used by compiler to help resolve class->method mappings
+     * Helper utility method used by compiler to help resolve class-&gt;method mappings
      * during method calls to {@link OgnlExpressionCompiler#getSuperOrInterfaceClass(java.lang.reflect.Method, Class)}.
      *
      * @param m

--- a/src/main/java/ognl/enhance/LocalReference.java
+++ b/src/main/java/ognl/enhance/LocalReference.java
@@ -14,7 +14,7 @@ public interface LocalReference {
     String getName();
 
     /**
-     * The expression that sets the value, ie the part after <code><class type> refName = <expression></code>.
+     * The expression that sets the value, ie the part after <code>&lt;class type&gt; refName = &lt;expression&gt;</code>.
      * @return The setting expression.
      */
     String getExpression();

--- a/src/main/java/ognl/security/UserMethod.java
+++ b/src/main/java/ognl/security/UserMethod.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Method;
 import java.security.PrivilegedExceptionAction;
 
 /**
- * A signature for {@link OgnlSecurityManager#isAccessDenied()}. Also executes user methods with not any permission.
+ * A signature for {@link OgnlSecurityManager#isAccessDenied(java.security.Permission)}. Also executes user methods with not any permission.
  *
  * @author Yasser Zamani
  * @since 3.1.24

--- a/src/test/java/ognl/DefaultMemberAccess.java
+++ b/src/test/java/ognl/DefaultMemberAccess.java
@@ -145,6 +145,12 @@ public class DefaultMemberAccess implements MemberAccess
     /**
         Returns true if the given member is accessible or can be made accessible
         by this object.
+     *
+     * @param context the current execution context (not used).
+     * @param target the Object to test accessibility for (not used).
+     * @param member the Member to test accessibility for.
+     * @param propertyName the property to test accessibility for (not used).
+     * @return true if the member is accessible in the context, false otherwise.
      */
 	public boolean isAccessible(Map context, Object target, Member member, String propertyName)
 	{


### PR DESCRIPTION
Forward-port PR#89 from 3.1.x to 3.2.x (cherry-pick).
- Cherry-pick PR#89 JavaDoc changes into 3.2.x.
- Update JavaDoc source version from 1.6 to 1.7.
- Update surefire plugin to latest 2.x available.
- Update javadoc comment in Ognl class causing build failure in JDK 8.