### PR TITLE
`OgnlRuntime#getReadMethod()` returns `null` if the method is a bridge method

### DIFF
--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -3597,9 +3597,6 @@ public class OgnlRuntime {
 
             for (int i = 0; i < methods.length; i++)
             {
-                if (!isMethodCallable(methods[i]))
-                    continue;
-
                 if ((methods[i].getName().equalsIgnoreCase(name)
                      || methods[i].getName().toLowerCase().equals("get" + name)
                      || methods[i].getName().toLowerCase().equals("has" + name)
@@ -3617,9 +3614,6 @@ public class OgnlRuntime {
 
             for (int i = 0; i < methods.length; i++)
             {
-                if (!isMethodCallable(methods[i]))
-                    continue;
-
                 if (methods[i].getName().equalsIgnoreCase(name)
                     && !methods[i].getName().startsWith("set")
                     && !methods[i].getName().startsWith("get")

--- a/src/test/java/ognl/TestOgnlRuntime.java
+++ b/src/test/java/ognl/TestOgnlRuntime.java
@@ -699,4 +699,23 @@ public class TestOgnlRuntime extends TestCase {
         }
     }
 
+    protected static class ProtectedParent {
+        public void setName(String name) {
+        }
+        public String getName() {
+            return "name";
+        }
+    }
+
+    public static class PublicChild extends ProtectedParent {
+    }
+
+    public void testSyntheticReadMethod() throws Exception {
+        assertNotNull(OgnlRuntime.getReadMethod(PublicChild.class, "name"));
+    }
+
+    public void testSyntheticWriteMethod() throws Exception {
+        assertNotNull(OgnlRuntime.getWriteMethod(PublicChild.class, "name"));
+    }
+
 }


### PR DESCRIPTION
Considering the following two classes, `OgnlRuntime.getReadMethod(PublicChild.class, "name")` should return the `getName()` method, but it returns `null` instead.

```java
package pkg1;

class PkgPrivateParent {
  public String getName() {
    return "";
  }
}
```

```java
package pkg1;

public class PublicChild extends PkgPrivateParent {
}
```

In the `getReadMethod()`, candidate methods are checked by `isMethodCallable()` which returns `false` for a bridge method even though it is callable.
I simply removed the 'is callable' check from `getReadMethod()` and there is no broken test.

p.s.
Note that this bug does not exists in `OgnlRuntime#getWriteMethod()` because it internally uses `BeanInfo#getMethodDescriptors()[i]#getMethod()#getModifiers()` which returns a different value than `Class#getMethods()[i]#getModifiers()` for some reason [1].
I added a test case to avoid possible regression in case someone wants to resolve the implementation inconsistency in future.

[1] Try the following code if you are curious.

```java
protected static class ProtectedParent {
    private String name;
    public void setName(String name) {
        this.name = name;
    }
    public String getName() {
        return name;
    }
}

public static class PublicChild extends ProtectedParent {
}

public void testSyntheticReadMethod() throws Exception {
    Method[] methods = PublicChild.class.getMethods();
    for (int i = 0; i < methods.length; i++) {
        if (methods[i].getName().endsWith("Name")) {
            System.out.println(methods[i].getModifiers()); // -> 4161
        }
    }
    BeanInfo beanInfo = Introspector.getBeanInfo(PublicChild.class);
    MethodDescriptor[] methodDescriptors = beanInfo.getMethodDescriptors();
    for (int i = 0; i < methodDescriptors.length; i++) {
        if (methodDescriptors[i].getMethod().getName().endsWith("Name")) {
            System.out.println(methodDescriptors[i].getMethod().getModifiers()); // -> 1
        }
    }
}
```
