### PR TITLE
resolve race condition problem

### DIFF
--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -2773,10 +2773,6 @@ public class OgnlRuntime {
         if (method != null)
             return method;
 
-        // By checking key existence now and not before calling 'get', we will save a map resolution 90% of the times
-//        if (cacheGetMethod.containsKey(targetClass, propertyName))
-//            return null;
-
         method = _getGetMethod(context, targetClass, propertyName); // will be null if not found - will cache it anyway
         cacheGetMethod.put(targetClass, propertyName, method);
 
@@ -3974,14 +3970,6 @@ public class OgnlRuntime {
             methodsByPropertyName.putIfAbsent(propertyName, (method == null? NULL_REPLACEMENT : method));
         }
 
-//        boolean containsKey(Class clazz, String propertyName)
-//        {
-//            ConcurrentHashMap<String,Method> methodsByPropertyName = this.cache.get(clazz);
-//            if (methodsByPropertyName == null)
-//                return false;
-//
-//            return methodsByPropertyName.containsKey(propertyName);
-//        }
 
         /**
          * Allow clearing for the underlying cache of the ClassPropertyMethodCache.

--- a/src/test/java/ognl/race/Base.java
+++ b/src/test/java/ognl/race/Base.java
@@ -1,0 +1,15 @@
+package ognl.race;
+
+/**
+ *
+ */
+public class Base {
+    private Boolean yn = true;
+    public Boolean getYn() {
+        return yn;
+    }
+
+    public void setYn(Boolean yn) {
+        this.yn = yn;
+    }
+}

--- a/src/test/java/ognl/race/Persion.java
+++ b/src/test/java/ognl/race/Persion.java
@@ -1,0 +1,14 @@
+package ognl.race;
+
+public class Persion extends Base{
+    private String name = "abc";
+
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/ognl/race/RaceTestCase.java
+++ b/src/test/java/ognl/race/RaceTestCase.java
@@ -1,0 +1,74 @@
+package ognl.race;
+
+
+import ognl.DefaultMemberAccess;
+import ognl.Ognl;
+import ognl.OgnlContext;
+import ognl.OgnlException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+public class RaceTestCase {
+
+    @Test
+    public void testOgnlRace(){
+        int concurrent = 128;
+        final int batchCount = 2000;
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch wait = new CountDownLatch(concurrent);
+        final AtomicInteger errCount = new AtomicInteger(0);
+
+        final Persion persion = new Persion();
+        for (int i = 0; i < concurrent;i++){
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        start.await();
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                    for(int j = 0; j < batchCount;j++){
+                        if(j % 2 == 0) {
+                            runValue(persion, "yn", errCount);
+                        } else {
+                            runValue(persion, "name", errCount);
+                        }
+                    }
+                    wait.countDown();
+                }
+            });
+            thread.setName("work-"+i);
+            thread.start();
+        }
+        start.countDown();
+        try {
+            wait.await();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+//        System.out.println("error:" + errCount.get());
+        Assert.assertTrue(errCount.get() == 0);
+    }
+
+
+
+    private void runValue(Persion persion,String name,AtomicInteger errCount) {
+        OgnlContext context = new OgnlContext(null,null,new DefaultMemberAccess(false));
+        context.setRoot(persion);
+        try {
+            Object value =  Ognl.getValue(name, context, context.getRoot());
+//            System.out.println(value);
+
+        } catch (OgnlException e) {
+            errCount.incrementAndGet();
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
I found a race condition problem which cause to throw NoSuchPropertyException when there are to many threads since version 3.1.2. Although it was resolved by trying to call method of "getReadMethod", it will loss some performance,  I think it is the best way  to resolve  race condition.