### PR TITLE
Update isMethodCallable() logic, re-introduce its usage for getReadMethod()

### DIFF
--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -2772,6 +2772,8 @@ public class OgnlRuntime {
      * 
      * Synthetic methods should be excluded in general, since calling such methods
      * could introduce unanticipated risks.
+     * 
+     * @since 3.2.16
      *
      * @param m The method to check.
      * @return True if the method should be callable (non-synethetic or bridge), false otherwise.


### PR DESCRIPTION
Follow-up to PR #104.
Small updates to OgnlRuntime, attempting to ensure more consistent behaviour for JDK7-11.
- Update OgnlRuntime isMethodCallable().  Removed (now) unnecessary isJDK15 check, added clearer logic and explanatory JavaDoc comments.
- Added OgnlRuntime isMethodCallable_BridgeOrNonSynthetic() for specialized usage such as choosing valid Read and Write methods.
- Made checks in getReadMethod() and getWiteMethod symmetric again.
- Added new unit tests to confirm expected behaviour with respect to bridge methods and synthetic methods.