### PR TITLE
Explicitly cast the Enum#compareTo argument

### DIFF
--- a/src/main/java/ognl/OgnlOps.java
+++ b/src/main/java/ognl/OgnlOps.java
@@ -91,7 +91,7 @@ public abstract class OgnlOps implements NumericTypes
                         break;
                     } else if ((v1 instanceof Enum<?> && v2 instanceof Enum<?>) &&
                                (v1.getClass() == v2.getClass() || ((Enum) v1).getDeclaringClass() == ((Enum) v2).getDeclaringClass())) {
-                        result = ((Enum) v1).compareTo(v2);
+                        result = ((Enum) v1).compareTo((Enum) v2);
                         break;
                     } else {
                         throw new IllegalArgumentException("invalid comparison: " + v1.getClass().getName() + " and "


### PR DESCRIPTION
Hello @lukaszlenart ,

javac works fine, but Eclipse JDT requires explicit casting.
It seems that the JLS is not clear about this.
