### PR TITLE
Avoid illegal reflective access when possible

### DIFF
--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -1790,8 +1790,7 @@ public class OgnlRuntime {
                             && Modifier.isPublic(m.getDeclaringClass().getModifiers())) {
                         mm = new MatchingMethod(m, score, report, mParameterTypes);
                         failure = null;
-                    } else if (!retsAreEqual && !m.getReturnType().isAssignableFrom(mm.mMethod.getReturnType()))
-                        System.err.println("Two methods with same method signature but return types conflict? \""+mm.mMethod+"\" and \""+m+"\" please report!");
+                    }
                 } else {
                     // two methods with same score - direct compare to find the better one...
                     // legacy wins over varargs

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -1788,9 +1788,6 @@ public class OgnlRuntime {
                     // it is the same method. we use the public one...
                     if (!Modifier.isPublic(mm.mMethod.getDeclaringClass().getModifiers())
                             && Modifier.isPublic(m.getDeclaringClass().getModifiers())) {
-                        if (!retsAreEqual && !mm.mMethod.getReturnType().isAssignableFrom(m.getReturnType()))
-                            System.err.println("Two methods with same method signature but return types conflict? \""+mm.mMethod+"\" and \""+m+"\" please report!");
-
                         mm = new MatchingMethod(m, score, report, mParameterTypes);
                         failure = null;
                     } else if (!retsAreEqual && !m.getReturnType().isAssignableFrom(mm.mMethod.getReturnType()))

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -1793,9 +1793,6 @@ public class OgnlRuntime {
 
                         mm = new MatchingMethod(m, score, report, mParameterTypes);
                         failure = null;
-                    } else if (!m.getDeclaringClass().isAssignableFrom(mm.mMethod.getDeclaringClass())) {
-                        // this should't happen
-                        System.err.println("Two methods with same method signature but not providing classes assignable? \""+mm.mMethod+"\" and \""+m+"\" please report!");
                     } else if (!retsAreEqual && !m.getReturnType().isAssignableFrom(mm.mMethod.getReturnType()))
                         System.err.println("Two methods with same method signature but return types conflict? \""+mm.mMethod+"\" and \""+m+"\" please report!");
                 } else {

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -2260,8 +2260,7 @@ public class OgnlRuntime {
                 continue;
             }
 
-            // skip over synthetic methods
-            if (!isMethodCallable(ma[i]))
+            if (!isMethodCallable_BridgeOrNonSynthetic(ma[i]))
                 continue;
 
             if (Modifier.isStatic(ma[i].getModifiers()) == staticMethods)

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -1782,12 +1782,12 @@ public class OgnlRuntime {
                 failure = null;
             } else if (mm.score == score) {
                 // it happens that we see the same method signature multiple times - for the current class or interfaces ...
-                // TODO why are all of them on the list and not only the most specific one?
                 // check for same signature
                 if (Arrays.equals(mm.mMethod.getParameterTypes(), m.getParameterTypes()) && mm.mMethod.getName().equals(m.getName())) {
                     boolean retsAreEqual = mm.mMethod.getReturnType().equals(m.getReturnType());
-                    // it is the same method. we use the most specific one...
-                    if (mm.mMethod.getDeclaringClass().isAssignableFrom(m.getDeclaringClass())) {
+                    // it is the same method. we use the public one...
+                    if (!Modifier.isPublic(mm.mMethod.getDeclaringClass().getModifiers())
+                            && Modifier.isPublic(m.getDeclaringClass().getModifiers())) {
                         if (!retsAreEqual && !mm.mMethod.getReturnType().isAssignableFrom(m.getReturnType()))
                             System.err.println("Two methods with same method signature but return types conflict? \""+mm.mMethod+"\" and \""+m+"\" please report!");
 

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -2253,13 +2253,6 @@ public class OgnlRuntime {
         }
         for (int i = 0, icount = ma.length; i < icount; i++)
         {
-            if (c.isInterface())
-            {
-                if (isDefaultMethod(ma[i]))
-                    addMethodToResult(result, ma[i]);
-                continue;
-            }
-
             if (!isMethodCallable_BridgeOrNonSynthetic(ma[i]))
                 continue;
 

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -562,4 +562,10 @@ public class OgnlRuntimeTest {
         Assert.assertTrue((Boolean) Ognl.getValue("containsKey(3L)",
                 defaultContext, root));
     }
+
+    @Test
+    public void shouldInvokeInterfaceMethod() throws Exception {
+        Assert.assertTrue((Boolean) Ognl.getValue("isEmpty()", defaultContext,
+                Collections.checkedCollection(new ArrayList<>(), String.class)));
+    }
 }

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -568,4 +568,24 @@ public class OgnlRuntimeTest {
         Assert.assertTrue((Boolean) Ognl.getValue("isEmpty()", defaultContext,
                 Collections.checkedCollection(new ArrayList<>(), String.class)));
     }
+
+    public interface I1 {
+        Integer getId();
+    }
+
+    public interface I2 {
+        Integer getId();
+    }
+
+    @Test
+    public void shouldMultipleInterfaceWithTheSameMethodBeFine()
+            throws Exception {
+        class C1 implements I1, I2 {
+            public Integer getId() {
+                return 100;
+            }
+        }
+        Assert.assertEquals(100,
+                Ognl.getValue("getId()", defaultContext, new C1()));
+    }
 }

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -588,4 +588,21 @@ public class OgnlRuntimeTest {
         Assert.assertEquals(100,
                 Ognl.getValue("getId()", defaultContext, new C1()));
     }
+
+    public interface I3<T> {
+        T get();
+    }
+
+    @Test
+    public void shouldTwoMethodsWithDifferentReturnTypeBeFine()
+            throws Exception {
+        class C1 implements I3<Long> {
+            @Override
+            public Long get() {
+                return 3L;
+            }
+        }
+        Assert.assertEquals(3L,
+                Ognl.getValue("get()", defaultContext, new C1()));
+    }
 }

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -555,4 +556,10 @@ public class OgnlRuntimeTest {
                 Ognl.getValue("codePointAt(1)", defaultContext, root));
     }
 
+    @Test
+    public void shouldInvokeSuperclassMethod() throws Exception {
+        Map<Long, Long> root = Collections.singletonMap(3L, 33L);
+        Assert.assertTrue((Boolean) Ognl.getValue("containsKey(3L)",
+                defaultContext, root));
+    }
 }

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -593,10 +593,14 @@ public class OgnlRuntimeTest {
         T get();
     }
 
+    public interface I4 {
+        Long get();
+    }
+
     @Test
     public void shouldTwoMethodsWithDifferentReturnTypeBeFine()
             throws Exception {
-        class C1 implements I3<Long> {
+        class C1 implements I3<Long>, I4 {
             @Override
             public Long get() {
                 return 3L;

--- a/src/test/java/ognl/OgnlRuntimeTest.java
+++ b/src/test/java/ognl/OgnlRuntimeTest.java
@@ -548,4 +548,11 @@ public class OgnlRuntimeTest {
         }
     }
 
+    @Test
+    public void shouldInvokeSyntheticBridgeMethod() throws Exception {
+        StringBuilder root = new StringBuilder("abc");
+        Assert.assertEquals((int) 'b',
+                Ognl.getValue("codePointAt(1)", defaultContext, root));
+    }
+
 }


### PR DESCRIPTION
As reported in #143 , making a method accessible is problematic in recent versions of Java ('illegal reflective access' warning on 9+ and InaccessibleObjectException on 16+).
This PR avoids some illegal reflective accesses that I found.
Please see the log message of each commit for the details.
